### PR TITLE
修正 macOS 建置流程：啟用 macOS 桌面支援並指定工作目錄

### DIFF
--- a/.github/workflows/macos-deploy.yml
+++ b/.github/workflows/macos-deploy.yml
@@ -27,7 +27,13 @@ jobs:
         run: flutter analyze
 
       # ---------- 建置 ----------
+      # 先啟用 macOS 桌面支援，使 Flutter 能產生 macOS 執行檔
+      - name: 啟用 macOS 桌面支援
+        run: flutter config --enable-macos-desktop
+
       - name: 建置 macOS 執行檔
+        # 指定專案根目錄，避免路徑錯誤
+        working-directory: ./
         run: flutter build macos --release
 
       # ---------- 產出 ----------


### PR DESCRIPTION
## 變更內容
- 在工作流程中啟用 macOS 桌面支援
- 建置步驟中明確指定專案根目錄為工作目錄

## 測試
- `flutter --version`（缺少 flutter_tools，無法完成）

------
https://chatgpt.com/codex/tasks/task_e_68a582288a2883249530940647e97cc1