### PR TITLE
修正 CI 靜態分析範圍避免本地套件錯誤

### DIFF
--- a/.github/workflows/macos-deploy.yml
+++ b/.github/workflows/macos-deploy.yml
@@ -50,7 +50,8 @@ jobs:
       # ---------- 程式檢查 ----------
       - name: 程式碼靜態分析
         working-directory: ${{ steps.where.outputs.dir }}
-        run: flutter analyze
+        # 僅檢查應用程式的 lib 目錄，避免分析本地套件造成錯誤
+        run: flutter analyze lib
 
       # ---------- 建置 ----------
       - name: 建置 macOS 執行檔

--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -12,6 +12,7 @@ include: package:flutter_lints/flutter.yaml
 analyzer:
   exclude:
     - local_plugins/** # 排除本地套件與範例，避免分析失敗
+    - flutter_ignore_plugin/** # 排除忽略套件，避免分析無意義程式碼
 
 linter:
   # The lint rules applied to this project can be customized in the


### PR DESCRIPTION
## 摘要
- 更新分析設定，排除無需檢查的忽略套件
- 調整 macOS workflow，使 flutter analyze 僅檢查 lib 目錄

## 測試
- `flutter analyze lib`（環境缺少 Flutter 無法執行）

------
https://chatgpt.com/codex/tasks/task_e_68a674d7aab883249bd5c0a2dfeca826