### PR TITLE
新增攝影機錄影頁面支援切換後鏡頭與 MP4 轉檔

### DIFF
--- a/web/camera.html
+++ b/web/camera.html
@@ -1,0 +1,120 @@
+<!DOCTYPE html>
+<html lang="zh-Hant">
+<head>
+  <meta charset="UTF-8" />
+  <title>攝影機錄影</title>
+  <!-- 引入 Element Plus 與 Vue 3 -->
+  <link rel="stylesheet" href="https://unpkg.com/element-plus/dist/index.css" />
+  <script src="https://unpkg.com/vue@3/dist/vue.global.prod.js"></script>
+  <script src="https://unpkg.com/element-plus/dist/index.full.js"></script>
+  <!-- 引入 ffmpeg.wasm 用於轉檔 -->
+  <script src="https://cdn.jsdelivr.net/npm/@ffmpeg/ffmpeg@0.12.4/dist/ffmpeg.min.js"></script>
+  <style>
+    body { margin: 0; padding: 20px; }
+    video { width: 100%; max-width: 640px; background: #000; }
+  </style>
+</head>
+<body>
+  <div id="app">
+    <!-- 影片預覽畫面 -->
+    <video ref="video" autoplay playsinline></video>
+    <div style="margin-top: 10px;">
+      <!-- 切換鏡頭與錄影控制按鈕 -->
+      <el-button type="primary" @click="toggleCamera">切換鏡頭</el-button>
+      <el-button type="success" @click="startRecording" :disabled="isRecording">開始錄影</el-button>
+      <el-button type="danger" @click="stopRecording" :disabled="!isRecording">停止錄影</el-button>
+    </div>
+  </div>
+
+  <script type="module">
+    const { createApp, ref, onMounted } = Vue;
+    // ---------- 方法區 ----------
+    const app = createApp({
+      setup() {
+        const video = ref(null); // 影片元素參考
+        let mediaStream = null; // 目前的媒體串流
+        let mediaRecorder = null; // MediaRecorder 物件
+        let facingMode = ref('environment'); // 當前鏡頭模式，預設使用後鏡頭
+        const isRecording = ref(false); // 是否正在錄影
+        let recordedChunks = []; // 暫存錄影資料
+
+        // 初始化攝影機
+        async function initCamera() {
+          if (mediaStream) {
+            mediaStream.getTracks().forEach(t => t.stop());
+          }
+          try {
+            // 使用 facingMode 指定前/後鏡頭
+            mediaStream = await navigator.mediaDevices.getUserMedia({
+              video: { facingMode: facingMode.value },
+              audio: true,
+            });
+            video.value.srcObject = mediaStream;
+          } catch (e) {
+            console.error('取得攝影機失敗', e);
+          }
+        }
+
+        // 切換前後鏡頭
+        async function toggleCamera() {
+          facingMode.value = facingMode.value === 'user' ? 'environment' : 'user';
+          await initCamera();
+        }
+
+        // 開始錄影
+        function startRecording() {
+          recordedChunks = [];
+          const options = { mimeType: 'video/webm; codecs=vp9' };
+          mediaRecorder = new MediaRecorder(mediaStream, options);
+          mediaRecorder.ondataavailable = e => {
+            if (e.data.size > 0) recordedChunks.push(e.data);
+          };
+          mediaRecorder.onstop = convertToMp4; // 錄影結束後轉檔
+          mediaRecorder.start();
+          isRecording.value = true;
+        }
+
+        // 停止錄影
+        function stopRecording() {
+          if (mediaRecorder && mediaRecorder.state !== 'inactive') {
+            mediaRecorder.stop();
+          }
+          isRecording.value = false;
+        }
+
+        // 使用 ffmpeg.wasm 將錄影轉為 mp4
+        async function convertToMp4() {
+          // 將錄影資料合併成 Blob
+          const webmBlob = new Blob(recordedChunks, { type: 'video/webm' });
+          const ffmpeg = FFmpeg.createFFmpeg({ log: true });
+          await ffmpeg.load();
+          // 將 webm 寫入 ffmpeg 虛擬檔案系統
+          ffmpeg.FS('writeFile', 'input.webm', await FFmpeg.fetchFile(webmBlob));
+          // 執行轉檔
+          await ffmpeg.run('-i', 'input.webm', 'output.mp4');
+          // 讀取轉換後的 mp4
+          const data = ffmpeg.FS('readFile', 'output.mp4');
+          const mp4Blob = new Blob([data.buffer], { type: 'video/mp4' });
+          const url = URL.createObjectURL(mp4Blob);
+          // 透過連結觸發下載
+          const a = document.createElement('a');
+          a.href = url;
+          a.download = 'record.mp4';
+          a.click();
+          URL.revokeObjectURL(url);
+        }
+
+        // ---------- 生命週期 ----------
+        onMounted(() => {
+          initCamera();
+        });
+
+        return { video, toggleCamera, startRecording, stopRecording, isRecording };
+      },
+    });
+
+    app.use(ElementPlus);
+    app.mount('#app');
+  </script>
+</body>
+</html>


### PR DESCRIPTION
## 摘要
- 新增 `camera.html`，以 Vue 3 與 Element Plus 建立錄影頁面
- 可在前後鏡頭間切換，錄影後自動透過 ffmpeg.wasm 轉檔為 MP4

## 測試
- `flutter analyze`（指令不存在）
- `apt-get install -y dart`（找不到套件）
- `apt-get install -y flutter`（找不到套件）

------
https://chatgpt.com/codex/tasks/task_e_68a6db8d42d48324968c863d61c93c1c