### PR TITLE
錄影頁面支援聲音錄製並保持預覽靜音

### DIFF
--- a/web/src/App.vue
+++ b/web/src/App.vue
@@ -48,16 +48,16 @@ async function startCamera() {
   if (mediaStream.value) {
     mediaStream.value.getTracks().forEach(t => t.stop())
   }
-  // 僅開啟影像串流並關閉聲音以避免回聲
+  // 開啟影像與聲音串流，預覽時靜音避免回聲
   mediaStream.value = await navigator.mediaDevices.getUserMedia({
     video: selectedDeviceId.value ? { deviceId: { exact: selectedDeviceId.value } } : true,
-    audio: false
+    audio: true
   })
   // 取得權限後重新整理鏡頭清單以便切換前後鏡頭
   await loadDevices()
   if (videoEl.value) {
     videoEl.value.srcObject = mediaStream.value
-    videoEl.value.muted = true
+    videoEl.value.muted = true // 靜音預覽避免聲音外放
     await videoEl.value.play()
   }
 }


### PR DESCRIPTION
## 摘要
- 啟用影像與聲音串流，錄影時可同時記錄聲音
- 預覽畫面持續靜音，避免聲音外放

## 測試
- `npm run build`
- `flutter test`（環境缺少 Flutter，指令無法執行）

------
https://chatgpt.com/codex/tasks/task_e_68a81cd953e48324a36e71ad1e004e28