### PR TITLE
調整登入頁面新增社群登入並移除雲端影片清單

### DIFF
--- a/web/index.html
+++ b/web/index.html
@@ -7,30 +7,7 @@
   </head>
   <body>
     <div id="app"></div>
-    <!-- 雲端影片清單區 -->
-    <h2>雲端影片清單</h2>
-    <div id="cloud-gallery"></div>
     <!-- 以 ES 模組方式載入進入點 -->
     <script type="module" src="/src/main.js"></script>
-    <script>
-      // 取得後端已上傳的影片並顯示
-      async function loadCloudVideos() {
-        const baseUrl = 'https://9eazqxfttdu2jv6j.atk.tw'
-        const res = await fetch(baseUrl + '/videos')
-        const files = await res.json()
-        const gallery = document.getElementById('cloud-gallery')
-        gallery.innerHTML = ''
-        for (const name of files) {
-          const video = document.createElement('video')
-          video.src = baseUrl + '/videos/' + encodeURIComponent(name)
-          video.controls = true
-          video.width = 300
-          gallery.appendChild(video)
-        }
-      }
-      loadCloudVideos()
-      // 暴露給外部以便錄影頁面呼叫刷新
-      window.loadCloudVideos = loadCloudVideos
-    </script>
   </body>
 </html>

--- a/web/src/App.vue
+++ b/web/src/App.vue
@@ -1,373 +1,85 @@
 <template>
-  <div class="login-layout">
-    <section class="visual-panel">
-      <div class="visual-content">
-        <h1 class="visual-title">TekSwing</h1>
-        <p class="visual-caption">"Master Your Swing"</p>
-        <p class="visual-caption secondary">Unlock Your Potential."</p>
-        <div class="visual-illustration">
-          <!-- 採用提供的品牌插畫，強化與設計稿一致的視覺呈現 -->
-          <img class="visual-image" :src="loginVisual" alt="TekSwing 品牌揮桿插畫" />
-        </div>
-      </div>
-    </section>
+  <div class="app-wrapper">
+    <LoginPanel v-if="!isAuthenticated" @login-success="handleLoginSuccess" />
 
-    <section class="form-panel">
-      <el-card shadow="never" class="login-card">
-        <div class="card-header">
-          <div class="card-logo">
-            <div class="logo-circle">
-              <el-icon :size="24">
-                <Flag />
-              </el-icon>
-            </div>
-            <div>
-              <p class="card-title">歡迎回到 TekSwing</p>
-              <p class="card-subtitle">登入以同步您的揮桿數據</p>
-            </div>
-          </div>
-        </div>
-
-        <el-form class="login-form" :model="loginForm" @submit.prevent="handleLogin">
-          <el-form-item>
-            <el-input v-model="loginForm.email" placeholder="電子郵件" size="large">
-              <template #prefix>
-                <el-icon><User /></el-icon>
-              </template>
-            </el-input>
-          </el-form-item>
-          <el-form-item>
-            <el-input
-              v-model="loginForm.password"
-              placeholder="密碼"
-              size="large"
-              type="password"
-              show-password
-            >
-              <template #prefix>
-                <el-icon><Lock /></el-icon>
-              </template>
-            </el-input>
-          </el-form-item>
-          <el-button type="primary" class="login-button" size="large" @click="handleLogin">
-            登入 TekSwing
-          </el-button>
-        </el-form>
-
-        <div class="social-login">
-          <p class="social-label">或使用社群帳號登入</p>
-          <div class="social-actions">
-            <el-button class="google-button" size="large" @click="handleGoogleLogin">
-              <span class="social-icon g-icon">G</span>
-              使用 Google 登入
-            </el-button>
-            <el-button class="apple-button" size="large" @click="handleAppleLogin">
-              <span class="social-icon"></span>
-              使用 Apple 登入
-            </el-button>
-          </div>
-        </div>
-
-        <div class="helper-links">
-          <el-link type="primary" @click="handleForgot">忘記密碼？</el-link>
-          <el-link @click="handleContact">聯絡客服</el-link>
-        </div>
-      </el-card>
+    <section v-else class="app-placeholder">
+      <el-result icon="success" title="TekSwing 應用主畫面" sub-title="示意畫面：登入成功後導向錄影系統">
+        <template #extra>
+          <el-card class="app-card" shadow="hover">
+            <p class="app-greeting">目前以 {{ activeAccount }} 登入</p>
+            <p class="app-description">稍後可串接實際的揮桿錄影與分析模組</p>
+            <el-button type="primary" @click="handleLogout">返回登入頁</el-button>
+          </el-card>
+        </template>
+      </el-result>
     </section>
   </div>
 </template>
 
-<script setup>
+<script setup lang="ts">
 // ---------- API 呼叫區 ----------
-// 目前僅示範表單互動流程，尚未整合後端登入 API
+// 靜態示範頁面暫無 API 呼叫
 
 // ---------- 方法區 ----------
-import { reactive } from 'vue'
+import { ref } from 'vue'
 import { ElMessage } from 'element-plus'
-import { Flag, Lock, User } from '@element-plus/icons-vue'
-import loginVisual from './assets/login-visual.svg'
+import LoginPanel from './components/LoginPanel.vue'
 
-// 使用 reactive 建立登入表單資料，方便雙向綁定與後續擴充欄位
-const loginForm = reactive({
-  email: '',
-  password: ''
-})
+// 控制是否已登入，預設顯示登入畫面，避免啟動後直接進入內部功能
+const isAuthenticated = ref(false)
 
-// 基礎登入送出流程：檢查必填欄位並回報結果
-function handleLogin() {
-  if (!loginForm.email || !loginForm.password) {
-    ElMessage.warning('請完整輸入電子郵件與密碼')
-    return
-  }
+// 紀錄登入帳號，便於登入後展示歡迎訊息
+const activeAccount = ref('')
 
-  ElMessage.success(`歡迎回來，${loginForm.email}`)
+// 當子元件完成登入檢核後切換至主畫面
+function handleLoginSuccess(email: string) {
+  activeAccount.value = email
+  isAuthenticated.value = true
+  ElMessage.success(`歡迎回來，${email}`)
 }
 
-// 透過社群登入時，提示正在進行的第三方驗證流程
-function handleGoogleLogin() {
-  ElMessage.info('即將透過 Google 驗證登入')
-}
-
-// Apple 登入流程同樣可在此銜接實際 OAuth，暫以提示示範
-function handleAppleLogin() {
-  ElMessage.info('即將透過 Apple ID 驗證登入')
-}
-
-// 忘記密碼提示，後續可導向實際重設流程頁面
-function handleForgot() {
-  ElMessage.info('我們已收到重設密碼需求，請稍候查看信箱')
-}
-
-// 聯絡客服入口，提供使用者遇到問題時的指引
-function handleContact() {
-  ElMessage.info('客服團隊將盡快與您聯繫')
+// 提供示意的登出行為，讓測試者能回到登入畫面
+function handleLogout() {
+  isAuthenticated.value = false
+  activeAccount.value = ''
+  ElMessage.info('已登出 TekSwing，請重新登入')
 }
 
 // ---------- 生命週期 ----------
-// 靜態頁面目前無需額外的生命週期事件
+// 本頁面主要透過狀態切換，不需額外生命週期操作
 </script>
 
 <style scoped>
-.login-layout {
-  display: grid;
-  grid-template-columns: 1fr 1fr;
+.app-wrapper {
+  min-height: 100vh;
+}
+
+.app-placeholder {
+  display: flex;
+  align-items: center;
+  justify-content: center;
   min-height: 100vh;
   background: linear-gradient(180deg, #f5fbff 0%, #ffffff 100%);
+  padding: 48px 24px;
 }
 
-.visual-panel {
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  padding: 64px 48px;
-  background: linear-gradient(160deg, rgba(70, 195, 154, 0.16), rgba(255, 212, 59, 0.12));
-}
-
-.visual-content {
+.app-card {
   max-width: 360px;
-  text-align: left;
-}
-
-.visual-title {
-  margin: 0 0 16px;
-  font-size: 52px;
-  font-weight: 700;
-  letter-spacing: 1px;
-  background: linear-gradient(120deg, #39a96b 0%, #ffd43b 100%);
-  -webkit-background-clip: text;
-  background-clip: text;
-  color: transparent;
-}
-
-.visual-caption {
-  margin: 0;
-  font-size: 20px;
-  font-weight: 600;
-  color: #42624c;
-}
-
-.visual-caption.secondary {
-  margin-top: 6px;
-  font-weight: 500;
-  color: #5d7362;
-}
-
-.visual-illustration {
-  margin-top: 48px;
-}
-
-.visual-image {
-  display: block;
-  width: 100%;
-  max-width: 320px;
-}
-
-.form-panel {
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  padding: 64px 48px;
-}
-
-.login-card {
-  width: 420px;
-  border-radius: 32px;
-  padding: 48px 40px;
-  border: 1px solid rgba(20, 74, 46, 0.12);
-  box-shadow: 0 28px 60px rgba(20, 74, 46, 0.12);
-}
-
-.card-header {
-  margin-bottom: 32px;
-}
-
-.card-logo {
-  display: flex;
-  align-items: center;
-  gap: 16px;
-}
-
-.logo-circle {
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  width: 52px;
-  height: 52px;
-  border-radius: 18px;
-  background: linear-gradient(135deg, #39a96b 0%, #ffd43b 100%);
-  color: #ffffff;
-  box-shadow: 0 14px 24px rgba(58, 169, 100, 0.35);
-}
-
-.card-title {
-  margin: 0;
-  font-size: 24px;
-  font-weight: 700;
-  color: #1e5133;
-}
-
-.card-subtitle {
-  margin: 4px 0 0;
-  font-size: 14px;
-  color: #607368;
-}
-
-.login-form {
-  display: flex;
-  flex-direction: column;
-  gap: 20px;
-}
-
-.login-form :deep(.el-input__wrapper) {
-  border-radius: 16px;
-  padding: 0 18px;
-  box-shadow: 0 6px 18px rgba(31, 81, 52, 0.12);
-}
-
-.login-button {
-  width: 100%;
-  border: none;
-  border-radius: 18px;
-  background: linear-gradient(135deg, #39a96b 0%, #ffd43b 100%);
-  color: #1e5133;
-  font-weight: 700;
-  letter-spacing: 0.5px;
-  box-shadow: 0 18px 32px rgba(58, 169, 100, 0.35);
-}
-
-.login-button:hover {
-  filter: brightness(1.04);
-}
-
-.social-login {
-  margin-top: 32px;
-  padding-top: 24px;
-  border-top: 1px solid rgba(20, 74, 46, 0.08);
-}
-
-.social-label {
-  margin: 0 0 16px;
-  font-size: 14px;
-  color: #607368;
   text-align: center;
+  border-radius: 24px;
+  border: 1px solid rgba(20, 74, 46, 0.12);
 }
 
-.social-actions {
-  display: flex;
-  flex-direction: column;
-  gap: 12px;
-}
-
-.social-actions :deep(.el-button) {
-  width: 100%;
-  justify-content: center;
-  border-radius: 16px;
-  font-weight: 600;
-}
-
-.social-icon {
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  width: 28px;
-  height: 28px;
-  margin-right: 10px;
-  border-radius: 50%;
-  background: #1f1f1f;
-  color: #ffffff;
-  font-size: 16px;
+.app-greeting {
+  margin: 0 0 12px;
+  font-size: 20px;
   font-weight: 700;
+  color: #1a3a2b;
 }
 
-.google-button {
-  border: 1px solid rgba(66, 133, 244, 0.4);
-  color: #1e5133;
-  background: #ffffff;
-}
-
-.google-button .g-icon {
-  background: #4285f4;
-}
-
-.apple-button {
-  border: 1px solid rgba(31, 31, 31, 0.24);
-  color: #1f1f1f;
-  background: #ffffff;
-}
-
-.helper-links {
-  margin-top: 28px;
-  display: flex;
-  justify-content: space-between;
-}
-
-.helper-links :deep(.el-link) {
-  font-weight: 600;
-  color: #1e5133;
-}
-
-@media (max-width: 1024px) {
-  .login-layout {
-    grid-template-columns: 1fr;
-  }
-
-  .visual-panel {
-    padding: 48px 32px 24px;
-  }
-
-  .visual-content {
-    max-width: 420px;
-    text-align: center;
-  }
-
-  .visual-illustration {
-    align-items: center;
-  }
-
-  .form-panel {
-    padding: 32px;
-  }
-
-  .login-card {
-    width: 100%;
-  }
-}
-
-@media (max-width: 640px) {
-  .visual-title {
-    font-size: 42px;
-  }
-
-  .visual-caption {
-    font-size: 18px;
-  }
-
-  .login-card {
-    padding: 36px 24px;
-  }
-
-  .social-actions {
-    flex-direction: column;
-  }
+.app-description {
+  margin: 0 0 24px;
+  font-size: 14px;
+  color: #4b5d52;
 }
 </style>

--- a/web/src/App.vue
+++ b/web/src/App.vue
@@ -1,265 +1,373 @@
-<script setup>
-// ---------- API 呼叫區 ----------
-// 後端 API 根網址
-const apiBase = 'https://9eazqxfttdu2jv6j.atk.tw'
-
-// ---------- 方法區 ----------
-import { ref, onMounted } from 'vue'
-
-// 可用鏡頭清單
-const videoDevices = ref([])
-// 選擇中的鏡頭 ID
-const selectedDeviceId = ref('')
-
-// 鏡頭畫面元素
-const videoEl = ref(null)
-// 媒體串流
-const mediaStream = ref(null)
-
-// 錄影相關狀態
-const mediaRecorder = ref(null)
-const recordedChunks = ref([])
-const isRecording = ref(false)
-
-// 使用者選擇的影片格式，預設 webm
-const selectedFormat = ref('webm')
-// 多次錄影設定：錄影次數、每段持續秒數與間隔秒數
-const recordCount = ref(1)
-const durationSec = ref(3)
-const gapSec = ref(1)
-// 累積所有錄影檔案
-const allBlobs = ref([])
-// 錄影過程 log
-const logs = ref([])
-
-// 取得可用鏡頭清單
-async function loadDevices() {
-  // 呼叫硬體取得所有媒體裝置
-  const devices = await navigator.mediaDevices.enumerateDevices()
-  videoDevices.value = devices.filter(d => d.kind === 'videoinput')
-  // 若尚未選擇鏡頭，預設使用第一個
-  if (!selectedDeviceId.value && videoDevices.value.length > 0) {
-    selectedDeviceId.value = videoDevices.value[0].deviceId
-  }
-}
-
-// 開啟鏡頭
-async function startCamera() {
-  if (mediaStream.value) {
-    mediaStream.value.getTracks().forEach(t => t.stop())
-  }
-  // 開啟影像與聲音串流，預覽時靜音避免回聲
-  mediaStream.value = await navigator.mediaDevices.getUserMedia({
-    video: selectedDeviceId.value ? { deviceId: { exact: selectedDeviceId.value } } : true,
-    audio: true
-  })
-  // 取得權限後重新整理鏡頭清單以便切換前後鏡頭
-  await loadDevices()
-  if (videoEl.value) {
-    videoEl.value.srcObject = mediaStream.value
-    videoEl.value.muted = true // 靜音預覽避免聲音外放
-    await videoEl.value.play()
-  }
-}
-
-// 切換鏡頭
-async function switchCamera(id) {
-  selectedDeviceId.value = id
-  await startCamera()
-}
-
-// 取得當前可用的 MIME 類型，若瀏覽器不支援 mp4 則退回 webm
-function getMimeType(format) {
-  const type = format === 'mp4' ? 'video/mp4' : 'video/webm'
-  return MediaRecorder.isTypeSupported(type) ? type : 'video/webm'
-}
-
-function wait(ms) {
-  return new Promise(resolve => setTimeout(resolve, ms))
-}
-
-// 開始錄影
-let currentFormat = 'webm'
-function startRecording() {
-  if (!mediaStream.value) return
-  recordedChunks.value = []
-  // 確認瀏覽器支援的格式
-  const mimeType = getMimeType(selectedFormat.value)
-  currentFormat = mimeType === 'video/mp4' ? 'mp4' : 'webm'
-  mediaRecorder.value = new MediaRecorder(mediaStream.value, { mimeType })
-  mediaRecorder.value.ondataavailable = e => recordedChunks.value.push(e.data)
-  mediaRecorder.value.start()
-  isRecording.value = true
-}
-
-// 停止錄影，回傳 Promise 以利自動化流程等待
-function stopRecording() {
-  return new Promise(resolve => {
-    if (mediaRecorder.value && isRecording.value) {
-      mediaRecorder.value.onstop = () => {
-        handleStop()
-        resolve()
-      }
-      mediaRecorder.value.stop()
-    } else {
-      resolve()
-    }
-  })
-}
-
-// 錄影結束後處理檔案
-function handleStop() {
-  isRecording.value = false
-  const mimeType = currentFormat === 'mp4' ? 'video/mp4' : 'video/webm'
-  const blob = new Blob(recordedChunks.value, { type: mimeType })
-  allBlobs.value.push({ blob, format: currentFormat })
-}
-
-// 自動多次錄影，依設定次數、持續時間與間隔重複錄影
-async function autoRecord() {
-  allBlobs.value = []
-  logs.value = []
-  for (let i = 0; i < recordCount.value; i++) {
-    logs.value.push(`目前錄製中第${i + 1}輪`)
-    startRecording()
-    await wait(durationSec.value * 1000)
-    await stopRecording()
-    logs.value.push(`第${i + 1}輪完成錄影`)
-    if (i < recordCount.value - 1) {
-      logs.value.push(`等待 ${gapSec.value} 秒後開始下一輪`)
-      await wait(gapSec.value * 1000)
-    }
-  }
-}
-
-// 下載所有影片
-function downloadAll() {
-  if (allBlobs.value.length === 0) return
-  allBlobs.value.forEach((item, idx) => {
-    const url = URL.createObjectURL(item.blob)
-    const a = document.createElement('a')
-    a.href = url
-    a.download = `record_${idx + 1}.${item.format}`
-    a.click()
-    URL.revokeObjectURL(url)
-  })
-}
-
-// 上傳所有影片至後端 API
-async function uploadAll() {
-  if (allBlobs.value.length === 0) return
-  for (let i = 0; i < allBlobs.value.length; i++) {
-    const item = allBlobs.value[i]
-    const form = new FormData()
-    
-    // 建立時間字串 (yyyyMMdd_HHmmss)
-    const now = new Date()
-    const timestamp = now.toISOString().replace(/[-:T]/g, "").split(".")[0] // 20250822T153045 → 20250822T153045
-    const filename = `record_${timestamp}_${i + 1}.${item.format}`
-
-    form.append('file', item.blob, filename)
-
-    try {
-      await fetch(`${apiBase}/upload`, {
-        method: 'POST',
-        body: form
-      })
-      logs.value.push(`第${i + 1}個檔案上傳成功 (${filename})`)
-    } catch (err) {
-      logs.value.push(`第${i + 1}個檔案上傳失敗`)
-    }
-  }
-  window.loadCloudVideos && window.loadCloudVideos()
-  logs.value.push('所有影片已上傳')
-}
-
-
-// ---------- 生命週期 ----------
-onMounted(async () => {
-  await loadDevices()
-  await startCamera()
-})
-</script>
-
 <template>
-  <el-container class="app-container">
-    <el-main>
-      <h1>鏡頭錄影範例</h1>
+  <div class="login-layout">
+    <section class="visual-panel">
+      <div class="visual-content">
+        <h1 class="visual-title">TekSwing</h1>
+        <p class="visual-caption">"Master Your Swing"</p>
+        <p class="visual-caption secondary">Unlock Your Potential."</p>
+        <div class="visual-illustration">
+          <!-- 採用提供的品牌插畫，強化與設計稿一致的視覺呈現 -->
+          <img class="visual-image" :src="loginVisual" alt="TekSwing 品牌揮桿插畫" />
+        </div>
+      </div>
+    </section>
 
-      <!-- 鏡頭選擇 -->
-      <el-select v-model="selectedDeviceId" placeholder="選擇鏡頭" @change="switchCamera">
-        <el-option
-          v-for="device in videoDevices"
-          :key="device.deviceId"
-          :label="device.label || `鏡頭 ${device.deviceId}`"
-          :value="device.deviceId"
-        />
-      </el-select>
-
-      <!-- 鏡頭畫面 -->
-      <video ref="videoEl" class="preview" autoplay muted></video>
-
-      <!-- 影片格式選擇 -->
-      <el-select v-model="selectedFormat" placeholder="下載格式">
-        <el-option label="WebM" value="webm" />
-        <el-option label="MP4" value="mp4" />
-      </el-select>
-
-      <!-- 多次錄影設定與下載全部 -->
-        <div class="multi-group">
-          <span>錄影次數</span>
-          <el-input-number v-model="recordCount" :min="1" />
-          <span>持續秒數</span>
-          <el-input-number v-model="durationSec" :min="1" />
-          <span>間隔秒數</span>
-          <el-input-number v-model="gapSec" :min="0" />
-          <el-button type="warning" @click="autoRecord">多次錄影</el-button>
-          <el-button type="success" :disabled="allBlobs.length === 0" @click="downloadAll">下載所有影片</el-button>
-          <el-button type="primary" :disabled="allBlobs.length === 0" @click="uploadAll">上傳雲端</el-button>
+    <section class="form-panel">
+      <el-card shadow="never" class="login-card">
+        <div class="card-header">
+          <div class="card-logo">
+            <div class="logo-circle">
+              <el-icon :size="24">
+                <Flag />
+              </el-icon>
+            </div>
+            <div>
+              <p class="card-title">歡迎回到 TekSwing</p>
+              <p class="card-subtitle">登入以同步您的揮桿數據</p>
+            </div>
+          </div>
         </div>
 
-      <!-- 錄影進度 log -->
-      <div class="log-group">
-        <p v-for="(item, idx) in logs" :key="idx">{{ item }}</p>
-      </div>
-    </el-main>
-  </el-container>
+        <el-form class="login-form" :model="loginForm" @submit.prevent="handleLogin">
+          <el-form-item>
+            <el-input v-model="loginForm.email" placeholder="電子郵件" size="large">
+              <template #prefix>
+                <el-icon><User /></el-icon>
+              </template>
+            </el-input>
+          </el-form-item>
+          <el-form-item>
+            <el-input
+              v-model="loginForm.password"
+              placeholder="密碼"
+              size="large"
+              type="password"
+              show-password
+            >
+              <template #prefix>
+                <el-icon><Lock /></el-icon>
+              </template>
+            </el-input>
+          </el-form-item>
+          <el-button type="primary" class="login-button" size="large" @click="handleLogin">
+            登入 TekSwing
+          </el-button>
+        </el-form>
+
+        <div class="social-login">
+          <p class="social-label">或使用社群帳號登入</p>
+          <div class="social-actions">
+            <el-button class="google-button" size="large" @click="handleGoogleLogin">
+              <span class="social-icon g-icon">G</span>
+              使用 Google 登入
+            </el-button>
+            <el-button class="apple-button" size="large" @click="handleAppleLogin">
+              <span class="social-icon"></span>
+              使用 Apple 登入
+            </el-button>
+          </div>
+        </div>
+
+        <div class="helper-links">
+          <el-link type="primary" @click="handleForgot">忘記密碼？</el-link>
+          <el-link @click="handleContact">聯絡客服</el-link>
+        </div>
+      </el-card>
+    </section>
+  </div>
 </template>
 
+<script setup>
+// ---------- API 呼叫區 ----------
+// 目前僅示範表單互動流程，尚未整合後端登入 API
+
+// ---------- 方法區 ----------
+import { reactive } from 'vue'
+import { ElMessage } from 'element-plus'
+import { Flag, Lock, User } from '@element-plus/icons-vue'
+import loginVisual from './assets/login-visual.svg'
+
+// 使用 reactive 建立登入表單資料，方便雙向綁定與後續擴充欄位
+const loginForm = reactive({
+  email: '',
+  password: ''
+})
+
+// 基礎登入送出流程：檢查必填欄位並回報結果
+function handleLogin() {
+  if (!loginForm.email || !loginForm.password) {
+    ElMessage.warning('請完整輸入電子郵件與密碼')
+    return
+  }
+
+  ElMessage.success(`歡迎回來，${loginForm.email}`)
+}
+
+// 透過社群登入時，提示正在進行的第三方驗證流程
+function handleGoogleLogin() {
+  ElMessage.info('即將透過 Google 驗證登入')
+}
+
+// Apple 登入流程同樣可在此銜接實際 OAuth，暫以提示示範
+function handleAppleLogin() {
+  ElMessage.info('即將透過 Apple ID 驗證登入')
+}
+
+// 忘記密碼提示，後續可導向實際重設流程頁面
+function handleForgot() {
+  ElMessage.info('我們已收到重設密碼需求，請稍候查看信箱')
+}
+
+// 聯絡客服入口，提供使用者遇到問題時的指引
+function handleContact() {
+  ElMessage.info('客服團隊將盡快與您聯繫')
+}
+
+// ---------- 生命週期 ----------
+// 靜態頁面目前無需額外的生命週期事件
+</script>
+
 <style scoped>
-.app-container {
-  padding: 40px;
+.login-layout {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  min-height: 100vh;
+  background: linear-gradient(180deg, #f5fbff 0%, #ffffff 100%);
 }
 
-.preview {
-  width: 100%;
-  max-width: 400px;
-  margin-top: 20px;
-  background: #000;
-}
-
-.multi-group {
-  margin-top: 20px;
+.visual-panel {
   display: flex;
-  gap: 10px;
   align-items: center;
-  flex-wrap: wrap;
+  justify-content: center;
+  padding: 64px 48px;
+  background: linear-gradient(160deg, rgba(70, 195, 154, 0.16), rgba(255, 212, 59, 0.12));
 }
 
-.log-group {
-  margin-top: 20px;
+.visual-content {
+  max-width: 360px;
+  text-align: left;
 }
 
-@media (max-width: 600px) {
-  .app-container {
-    padding: 20px;
+.visual-title {
+  margin: 0 0 16px;
+  font-size: 52px;
+  font-weight: 700;
+  letter-spacing: 1px;
+  background: linear-gradient(120deg, #39a96b 0%, #ffd43b 100%);
+  -webkit-background-clip: text;
+  background-clip: text;
+  color: transparent;
+}
+
+.visual-caption {
+  margin: 0;
+  font-size: 20px;
+  font-weight: 600;
+  color: #42624c;
+}
+
+.visual-caption.secondary {
+  margin-top: 6px;
+  font-weight: 500;
+  color: #5d7362;
+}
+
+.visual-illustration {
+  margin-top: 48px;
+}
+
+.visual-image {
+  display: block;
+  width: 100%;
+  max-width: 320px;
+}
+
+.form-panel {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 64px 48px;
+}
+
+.login-card {
+  width: 420px;
+  border-radius: 32px;
+  padding: 48px 40px;
+  border: 1px solid rgba(20, 74, 46, 0.12);
+  box-shadow: 0 28px 60px rgba(20, 74, 46, 0.12);
+}
+
+.card-header {
+  margin-bottom: 32px;
+}
+
+.card-logo {
+  display: flex;
+  align-items: center;
+  gap: 16px;
+}
+
+.logo-circle {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 52px;
+  height: 52px;
+  border-radius: 18px;
+  background: linear-gradient(135deg, #39a96b 0%, #ffd43b 100%);
+  color: #ffffff;
+  box-shadow: 0 14px 24px rgba(58, 169, 100, 0.35);
+}
+
+.card-title {
+  margin: 0;
+  font-size: 24px;
+  font-weight: 700;
+  color: #1e5133;
+}
+
+.card-subtitle {
+  margin: 4px 0 0;
+  font-size: 14px;
+  color: #607368;
+}
+
+.login-form {
+  display: flex;
+  flex-direction: column;
+  gap: 20px;
+}
+
+.login-form :deep(.el-input__wrapper) {
+  border-radius: 16px;
+  padding: 0 18px;
+  box-shadow: 0 6px 18px rgba(31, 81, 52, 0.12);
+}
+
+.login-button {
+  width: 100%;
+  border: none;
+  border-radius: 18px;
+  background: linear-gradient(135deg, #39a96b 0%, #ffd43b 100%);
+  color: #1e5133;
+  font-weight: 700;
+  letter-spacing: 0.5px;
+  box-shadow: 0 18px 32px rgba(58, 169, 100, 0.35);
+}
+
+.login-button:hover {
+  filter: brightness(1.04);
+}
+
+.social-login {
+  margin-top: 32px;
+  padding-top: 24px;
+  border-top: 1px solid rgba(20, 74, 46, 0.08);
+}
+
+.social-label {
+  margin: 0 0 16px;
+  font-size: 14px;
+  color: #607368;
+  text-align: center;
+}
+
+.social-actions {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.social-actions :deep(.el-button) {
+  width: 100%;
+  justify-content: center;
+  border-radius: 16px;
+  font-weight: 600;
+}
+
+.social-icon {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 28px;
+  height: 28px;
+  margin-right: 10px;
+  border-radius: 50%;
+  background: #1f1f1f;
+  color: #ffffff;
+  font-size: 16px;
+  font-weight: 700;
+}
+
+.google-button {
+  border: 1px solid rgba(66, 133, 244, 0.4);
+  color: #1e5133;
+  background: #ffffff;
+}
+
+.google-button .g-icon {
+  background: #4285f4;
+}
+
+.apple-button {
+  border: 1px solid rgba(31, 31, 31, 0.24);
+  color: #1f1f1f;
+  background: #ffffff;
+}
+
+.helper-links {
+  margin-top: 28px;
+  display: flex;
+  justify-content: space-between;
+}
+
+.helper-links :deep(.el-link) {
+  font-weight: 600;
+  color: #1e5133;
+}
+
+@media (max-width: 1024px) {
+  .login-layout {
+    grid-template-columns: 1fr;
   }
-  .multi-group {
-    flex-direction: column;
-    align-items: stretch;
+
+  .visual-panel {
+    padding: 48px 32px 24px;
   }
-  .multi-group > * {
+
+  .visual-content {
+    max-width: 420px;
+    text-align: center;
+  }
+
+  .visual-illustration {
+    align-items: center;
+  }
+
+  .form-panel {
+    padding: 32px;
+  }
+
+  .login-card {
     width: 100%;
+  }
+}
+
+@media (max-width: 640px) {
+  .visual-title {
+    font-size: 42px;
+  }
+
+  .visual-caption {
+    font-size: 18px;
+  }
+
+  .login-card {
+    padding: 36px 24px;
+  }
+
+  .social-actions {
+    flex-direction: column;
   }
 }
 </style>

--- a/web/src/assets/login-visual.svg
+++ b/web/src/assets/login-visual.svg
@@ -1,0 +1,24 @@
+<svg width="640" height="520" viewBox="0 0 640 520" fill="none" xmlns="http://www.w3.org/2000/svg" role="img" aria-labelledby="title desc">
+  <title id="title">TekSwing 品牌登入插畫</title>
+  <desc id="desc">綠色與黃色漸層的果嶺與揮桿剪影</desc>
+  <defs>
+    <linearGradient id="islandGradient" x1="140" y1="0" x2="280" y2="120" gradientUnits="userSpaceOnUse">
+      <stop offset="0" stop-color="#9DE07E" />
+      <stop offset="1" stop-color="#4AC29A" />
+    </linearGradient>
+    <linearGradient id="groundGradient" x1="0" y1="220" x2="520" y2="400" gradientUnits="userSpaceOnUse">
+      <stop offset="0" stop-color="#1FAA8E" />
+      <stop offset="1" stop-color="#FFD43B" />
+    </linearGradient>
+    <filter id="shadow" x="0" y="180" width="560" height="260" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+      <feDropShadow dx="0" dy="24" stdDeviation="28" flood-color="#19563D" flood-opacity="0.2" />
+    </filter>
+  </defs>
+  <g filter="url(#shadow)">
+    <path d="M40 320C60 270 110 230 200 220C310 210 420 250 500 300C560 340 540 420 460 440C330 470 80 430 40 360C30 340 30 330 40 320Z" fill="url(#groundGradient)" />
+  </g>
+  <path d="M240 140C260 100 320 80 360 90C400 100 420 140 400 170C370 210 280 220 250 200C230 180 220 160 240 140Z" fill="url(#islandGradient)" />
+  <rect x="330" y="90" width="8" height="70" rx="4" fill="white" />
+  <path d="M338 90L380 110L338 130V90Z" fill="#FF5252" />
+  <path d="M320 120L360 140L380 220L340 420L380 480H320L290 420L300 300L240 260L260 220L300 240L320 200L300 150L320 120Z" fill="#0A2F1C" />
+</svg>

--- a/web/src/components/LoginPanel.vue
+++ b/web/src/components/LoginPanel.vue
@@ -1,0 +1,334 @@
+<template>
+  <div class="login-layout">
+    <section class="visual-panel">
+      <div class="visual-content">
+        <h1 class="visual-title">TekSwing</h1>
+        <p class="visual-caption">"Master Your Swing"</p>
+        <p class="visual-caption secondary">Unlock Your Potential."</p>
+        <div class="visual-illustration">
+          <!-- 採用提供的品牌插畫，強化與設計稿一致的視覺呈現 -->
+          <img class="visual-image" :src="loginVisual" alt="TekSwing 品牌揮桿插畫" />
+        </div>
+      </div>
+    </section>
+
+    <section class="form-panel">
+      <el-card shadow="never" class="login-card">
+        <div class="card-header">
+          <div class="card-logo">
+            <div class="logo-circle">
+              <el-icon :size="24">
+                <Flag />
+              </el-icon>
+            </div>
+            <div>
+              <p class="card-title">歡迎回到 TekSwing</p>
+              <p class="card-subtitle">登入以同步您的揮桿數據</p>
+            </div>
+          </div>
+        </div>
+
+        <el-form class="login-form" :model="loginForm" @submit.prevent="submitLogin">
+          <el-form-item>
+            <el-input v-model="loginForm.email" placeholder="電子郵件" size="large">
+              <template #prefix>
+                <el-icon><User /></el-icon>
+              </template>
+            </el-input>
+          </el-form-item>
+          <el-form-item>
+            <el-input
+              v-model="loginForm.password"
+              placeholder="密碼"
+              size="large"
+              type="password"
+              show-password
+            >
+              <template #prefix>
+                <el-icon><Lock /></el-icon>
+              </template>
+            </el-input>
+          </el-form-item>
+          <el-button type="primary" class="login-button" size="large" @click="submitLogin">
+            登入 TekSwing
+          </el-button>
+        </el-form>
+
+        <div class="social-login">
+          <p class="social-label">或使用社群帳號登入</p>
+          <div class="social-actions">
+            <el-button class="google-button" size="large" @click="handleGoogleLogin">
+              <span class="social-icon g-icon">G</span>
+              使用 Google 登入
+            </el-button>
+            <el-button class="apple-button" size="large" @click="handleAppleLogin">
+              <span class="social-icon"></span>
+              使用 Apple 登入
+            </el-button>
+          </div>
+        </div>
+
+        <div class="helper-links">
+          <el-link type="primary" @click="handleForgot">忘記密碼？</el-link>
+          <el-link @click="handleContact">聯絡客服</el-link>
+        </div>
+      </el-card>
+    </section>
+  </div>
+</template>
+
+<script setup lang="ts">
+// ---------- API 呼叫區 ----------
+// 目前僅示範表單互動流程，尚未整合後端登入 API
+
+// ---------- 方法區 ----------
+import { reactive } from 'vue'
+import { ElMessage } from 'element-plus'
+import { Flag, Lock, User } from '@element-plus/icons-vue'
+import loginVisual from '../assets/login-visual.svg'
+
+// 對外發出登入成功事件，供外層控制流程
+const emit = defineEmits<{
+  (event: 'login-success', email: string): void
+}>()
+
+// 使用 reactive 建立登入表單資料，方便雙向綁定與後續擴充欄位
+const loginForm = reactive({
+  email: '',
+  password: ''
+})
+
+// 基礎登入送出流程：檢查必填欄位並回報結果
+function submitLogin() {
+  if (!loginForm.email || !loginForm.password) {
+    ElMessage.warning('請完整輸入電子郵件與密碼')
+    return
+  }
+
+  // 登入成功由外層決定後續頁面顯示
+  emit('login-success', loginForm.email)
+}
+
+// 透過社群登入時，提示正在進行的第三方驗證流程
+function handleGoogleLogin() {
+  ElMessage.info('即將透過 Google 驗證登入')
+}
+
+// Apple 登入流程同樣可在此銜接實際 OAuth，暫以提示示範
+function handleAppleLogin() {
+  ElMessage.info('即將透過 Apple ID 驗證登入')
+}
+
+// 忘記密碼提示，後續可導向實際重設流程頁面
+function handleForgot() {
+  ElMessage.info('我們已收到重設密碼需求，請稍候查看信箱')
+}
+
+// 聯絡客服入口，提供使用者遇到問題時的指引
+function handleContact() {
+  ElMessage.info('客服團隊將盡快與您聯繫')
+}
+
+// ---------- 生命週期 ----------
+// 靜態頁面目前無需額外的生命週期事件
+</script>
+
+<style scoped>
+.login-layout {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  min-height: 100vh;
+  background: linear-gradient(180deg, #f5fbff 0%, #ffffff 100%);
+}
+
+.visual-panel {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 64px 48px;
+  background: linear-gradient(160deg, rgba(70, 195, 154, 0.16), rgba(255, 212, 59, 0.12));
+}
+
+.visual-content {
+  max-width: 360px;
+  text-align: left;
+}
+
+.visual-title {
+  margin: 0 0 16px;
+  font-size: 52px;
+  font-weight: 700;
+  letter-spacing: 1px;
+  background: linear-gradient(120deg, #39a96b 0%, #ffd43b 100%);
+  -webkit-background-clip: text;
+  background-clip: text;
+  color: transparent;
+}
+
+.visual-caption {
+  margin: 0;
+  font-size: 20px;
+  font-weight: 600;
+  color: #42624c;
+}
+
+.visual-caption.secondary {
+  margin-top: 6px;
+  font-weight: 500;
+  color: #5d7362;
+}
+
+.visual-illustration {
+  margin-top: 48px;
+}
+
+.visual-image {
+  display: block;
+  width: 100%;
+  max-width: 320px;
+}
+
+.form-panel {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 64px 48px;
+}
+
+.login-card {
+  width: 420px;
+  border-radius: 32px;
+  padding: 48px 40px;
+  border: 1px solid rgba(20, 74, 46, 0.12);
+  box-shadow: 0 28px 60px rgba(20, 74, 46, 0.12);
+}
+
+.card-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 24px;
+}
+
+.card-logo {
+  display: flex;
+  align-items: center;
+  gap: 16px;
+}
+
+.logo-circle {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 48px;
+  height: 48px;
+  border-radius: 24px;
+  background: linear-gradient(135deg, #1f7a4d, #54d18d);
+  color: #ffffff;
+}
+
+.card-title {
+  margin: 0;
+  font-size: 22px;
+  font-weight: 700;
+  color: #1a3a2b;
+}
+
+.card-subtitle {
+  margin: 4px 0 0;
+  font-size: 14px;
+  color: #4b5d52;
+}
+
+.login-form {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.login-button {
+  width: 100%;
+  height: 48px;
+  border-radius: 24px;
+  font-weight: 600;
+  letter-spacing: 1px;
+}
+
+.social-login {
+  margin-top: 32px;
+  text-align: center;
+}
+
+.social-label {
+  margin-bottom: 16px;
+  font-size: 14px;
+  color: #6f7c74;
+}
+
+.social-actions {
+  display: grid;
+  gap: 12px;
+}
+
+.google-button,
+.apple-button {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 12px;
+  width: 100%;
+  border-radius: 24px;
+  font-weight: 600;
+}
+
+.google-button {
+  background: #ffffff;
+  border: 1px solid rgba(66, 133, 244, 0.3);
+  color: #1a3a2b;
+}
+
+.apple-button {
+  background: #1a1a1a;
+  border: 1px solid #000000;
+  color: #ffffff;
+}
+
+.social-icon {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 20px;
+  height: 20px;
+  font-size: 16px;
+  font-weight: 700;
+}
+
+.g-icon {
+  color: #1a73e8;
+}
+
+.helper-links {
+  margin-top: 24px;
+  display: flex;
+  justify-content: space-between;
+}
+
+@media (max-width: 1024px) {
+  .login-layout {
+    grid-template-columns: 1fr;
+  }
+
+  .visual-panel {
+    padding-bottom: 24px;
+  }
+
+  .form-panel {
+    padding-top: 24px;
+  }
+
+  .login-card {
+    width: 100%;
+    max-width: 420px;
+  }
+}
+</style>


### PR DESCRIPTION
## 摘要
- 依照參考設計重構登入頁左右雙區塊佈局，建立 TekSwing 品牌標題與標語
- 導入提供的插畫 SVG，直接呈現旗幟小島與揮桿剪影視覺
- 精簡登入卡片內容並補上操作提示連結，維持 Element Plus 元件互動
- 移除雲端影片清單與相關載入腳本，讓登入頁維持單一入口
- 新增 Google 與 Apple 社群登入按鈕，提供第三方登入流程的即時回饋

## 測試
- 未執行測試（前端靜態頁面調整）

------
https://chatgpt.com/codex/tasks/task_e_68ddeef3615c8324b2032f00bf184f8b