### PR TITLE
改用拍照縮圖並清理失效縮圖紀錄

### DIFF
--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -1,8 +1,21 @@
 plugins {
     id("com.android.application")
-    id("kotlin-android")
+    // ---------- 套用 Kotlin 外掛 ----------
+    // 改用完整外掛識別名稱，確保沿用 settings.gradle.kts 中宣告的 2.0.21 版本
+    id("org.jetbrains.kotlin.android")
     // The Flutter Gradle Plugin must be applied after the Android and Kotlin Gradle plugins.
     id("dev.flutter.flutter-gradle-plugin")
+}
+
+// ---------- 依賴解析區 ----------
+// 統一所有 Kotlin 標準函式庫為 2.0.21，確保與編譯器版本相容
+configurations.all {
+    resolutionStrategy.eachDependency {
+        if (requested.group == "org.jetbrains.kotlin" && requested.name.startsWith("kotlin-")) {
+            useVersion("2.0.21")
+            because("回退 Kotlin 版本以保持與第三方外掛的兼容性")
+        }
+    }
 }
 
 android {

--- a/android/app/src/debug/AndroidManifest.xml
+++ b/android/app/src/debug/AndroidManifest.xml
@@ -9,4 +9,13 @@
     <uses-permission android:name="android.permission.CAMERA"/>
     <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE"/>
     <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE"/>
+    <!-- 開發階段也同步宣告藍牙與定位權限，確保測試版能出現相同授權選項 -->
+    <uses-permission android:name="android.permission.BLUETOOTH" android:maxSdkVersion="30"/>
+    <uses-permission android:name="android.permission.BLUETOOTH_ADMIN" android:maxSdkVersion="30"/>
+    <uses-permission
+        android:name="android.permission.BLUETOOTH_SCAN"
+        android:usesPermissionFlags="neverForLocation"/>
+    <uses-permission android:name="android.permission.BLUETOOTH_CONNECT"/>
+    <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION"/>
+    <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION"/>
 </manifest>

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -1,8 +1,25 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
+    <!-- 採集 IMU 感測資料需要藍牙、定位與錄影等權限，於此宣告以顯示在系統權限管理中 -->
     <uses-permission android:name="android.permission.RECORD_AUDIO"/>
     <uses-permission android:name="android.permission.CAMERA"/>
     <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" android:maxSdkVersion="28"/>
     <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE"/>
+    <!-- Android 12 以前的裝置仍需傳統藍牙權限才能完成掃描與連線 -->
+    <uses-permission android:name="android.permission.BLUETOOTH" android:maxSdkVersion="30"/>
+    <uses-permission android:name="android.permission.BLUETOOTH_ADMIN" android:maxSdkVersion="30"/>
+    <!-- Android 12 起改用附近裝置權限，搭配 neverForLocation 標記避免額外定位需求 -->
+    <uses-permission
+        android:name="android.permission.BLUETOOTH_SCAN"
+        android:usesPermissionFlags="neverForLocation"/>
+    <uses-permission android:name="android.permission.BLUETOOTH_CONNECT"/>
+    <!-- 掃描 BLE 裝置仍須定位授權，於此明確宣告顯示在應用權限頁 -->
+    <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION"/>
+    <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION"/>
+
+    <!-- 聲明支援藍牙低功耗以通過 Play Store 審查，也允許無 BLE 裝置仍可安裝 -->
+    <uses-feature
+        android:name="android.hardware.bluetooth_le"
+        android:required="false"/>
 
     <application
         android:label="golf_score_app"
@@ -35,6 +52,15 @@
         <meta-data
             android:name="flutterEmbedding"
             android:value="2" />
+        <provider
+            android:name="androidx.core.content.FileProvider"
+            android:authorities="${applicationId}.fileprovider"
+            android:exported="false"
+            android:grantUriPermissions="true">
+            <meta-data
+                android:name="android.support.FILE_PROVIDER_PATHS"
+                android:resource="@xml/file_paths" />
+        </provider>
     </application>
     <!-- Required to query activities that can process text, see:
          https://developer.android.com/training/package-visibility and

--- a/android/app/src/main/kotlin/com/example/golf_score_app/MainActivity.kt
+++ b/android/app/src/main/kotlin/com/example/golf_score_app/MainActivity.kt
@@ -1,18 +1,79 @@
 package com.example.golf_score_app
 
+import android.content.Intent
+import android.net.Uri
 import android.os.Bundle
 import android.view.KeyEvent
+import androidx.core.content.FileProvider
 import io.flutter.embedding.android.FlutterActivity
 import io.flutter.embedding.engine.FlutterEngine
 import io.flutter.plugin.common.MethodChannel
+import java.io.File
 
 class MainActivity: FlutterActivity() {
     private val CHANNEL = "volume_button_channel"
+    private val SHARE_CHANNEL = "share_intent_channel"
 
     override fun configureFlutterEngine(flutterEngine: FlutterEngine) {
         super.configureFlutterEngine(flutterEngine)
         MethodChannel(flutterEngine.dartExecutor.binaryMessenger, CHANNEL)
             .setMethodCallHandler { _, _ -> }
+        MethodChannel(flutterEngine.dartExecutor.binaryMessenger, SHARE_CHANNEL)
+            .setMethodCallHandler { call, result ->
+                if (call.method == "shareToPackage") {
+                    val packageName = call.argument<String>("packageName")
+                    val filePath = call.argument<String>("filePath")
+                    val mimeType = call.argument<String>("mimeType") ?: "video/*"
+                    val text = call.argument<String>("text")
+
+                    if (packageName.isNullOrBlank() || filePath.isNullOrBlank()) {
+                        result.error("invalid_args", "缺少必要參數", null)
+                        return@setMethodCallHandler
+                    }
+
+                    val file = File(filePath)
+                    if (!file.exists()) {
+                        result.error("file_not_found", "找不到指定影片檔案", null)
+                        return@setMethodCallHandler
+                    }
+
+                    val uri: Uri = FileProvider.getUriForFile(
+                        this,
+                        "${applicationContext.packageName}.fileprovider",
+                        file
+                    )
+
+                    val intent = Intent(Intent.ACTION_SEND).apply {
+                        type = mimeType
+                        setPackage(packageName)
+                        putExtra(Intent.EXTRA_STREAM, uri)
+                        addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION)
+                        if (!text.isNullOrEmpty()) {
+                            putExtra(Intent.EXTRA_TEXT, text)
+                        }
+                    }
+
+                    val resolveInfo = intent.resolveActivity(packageManager)
+                    if (resolveInfo == null) {
+                        result.success(false)
+                        return@setMethodCallHandler
+                    }
+
+                    try {
+                        grantUriPermission(
+                            packageName,
+                            uri,
+                            Intent.FLAG_GRANT_READ_URI_PERMISSION
+                        )
+                        startActivity(intent)
+                        result.success(true)
+                    } catch (error: Exception) {
+                        result.success(false)
+                    }
+                } else {
+                    result.notImplemented()
+                }
+            }
     }
 
     override fun onKeyDown(keyCode: Int, event: KeyEvent): Boolean {

--- a/android/app/src/main/res/xml/file_paths.xml
+++ b/android/app/src/main/res/xml/file_paths.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<paths xmlns:android="http://schemas.android.com/apk/res/android">
+    <!-- 允許分享應用內部及外部儲存的影片檔案 -->
+    <files-path name="internal_videos" path="." />
+    <external-files-path name="external_videos" path="." />
+</paths>

--- a/android/app/src/profile/AndroidManifest.xml
+++ b/android/app/src/profile/AndroidManifest.xml
@@ -4,4 +4,13 @@
          to allow setting breakpoints, to provide hot reload, etc.
     -->
     <uses-permission android:name="android.permission.INTERNET"/>
+    <!-- 發佈前的 profile 版本同樣需要宣告藍牙與定位權限，以便 QA 驗證權限流程 -->
+    <uses-permission android:name="android.permission.BLUETOOTH" android:maxSdkVersion="30"/>
+    <uses-permission android:name="android.permission.BLUETOOTH_ADMIN" android:maxSdkVersion="30"/>
+    <uses-permission
+        android:name="android.permission.BLUETOOTH_SCAN"
+        android:usesPermissionFlags="neverForLocation"/>
+    <uses-permission android:name="android.permission.BLUETOOTH_CONNECT"/>
+    <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION"/>
+    <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION"/>
 </manifest>

--- a/android/settings.gradle.kts
+++ b/android/settings.gradle.kts
@@ -19,7 +19,10 @@ pluginManagement {
 plugins {
     id("dev.flutter.flutter-plugin-loader") version "1.0.0"
     id("com.android.application") version "8.7.0" apply false
-    id("org.jetbrains.kotlin.android") version "1.8.22" apply false
+    // ---------- Kotlin 版本說明 ----------
+    // 受限於部分 Flutter 套件仍使用較舊的 Kotlin 編譯器，我們改回 2.0.21 並搭配對應版本的標準函式庫
+    // 如此能與 package_info_plus 等套件維持相容，避免 metadata 版本衝突
+    id("org.jetbrains.kotlin.android") version "2.0.21" apply false
 }
 
 include(":app")

--- a/ios/Runner/Info.plist
+++ b/ios/Runner/Info.plist
@@ -41,9 +41,16 @@
 		<string>UIInterfaceOrientationLandscapeLeft</string>
 		<string>UIInterfaceOrientationLandscapeRight</string>
 	</array>
-	<key>CADisableMinimumFrameDurationOnPhone</key>
-	<true/>
-	<key>UIApplicationSupportsIndirectInputEvents</key>
-	<true/>
+        <key>CADisableMinimumFrameDurationOnPhone</key>
+        <true/>
+        <key>UIApplicationSupportsIndirectInputEvents</key>
+        <true/>
+        <!-- 宣告藍牙與定位用途說明，確保 iOS 顯示授權提示與設定頁項目 -->
+        <key>NSBluetoothAlwaysUsageDescription</key>
+        <string>需要藍牙權限以搜尋並連線 IMU 感測裝置。</string>
+        <key>NSBluetoothPeripheralUsageDescription</key>
+        <string>需要藍牙權限以維持與 IMU 的穩定連線與資料交換。</string>
+        <key>NSLocationWhenInUseUsageDescription</key>
+        <string>需要定位權限以偵測附近的藍牙 IMU 設備並完成配對。</string>
 </dict>
 </plist>

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,416 +1,125 @@
-import 'dart:async';
-import 'dart:io';
-import 'dart:isolate';
-import 'package:flutter/material.dart';
 import 'package:camera/camera.dart';
-import 'package:flutter_audio_capture/flutter_audio_capture.dart';
-import 'package:permission_handler/permission_handler.dart';
-import 'dart:developer';
-import 'dart:math' as math;
-import 'package:file_picker/file_picker.dart';
-import 'package:video_player/video_player.dart';
-import 'package:assets_audio_player/assets_audio_player.dart';
-import 'package:flutter/services.dart';
+import 'package:flutter/material.dart';
 
-void main() async {
+import 'pages/login_page.dart';
+
+Future<void> main() async {
+  // 先初始化 Flutter 綁定，避免在呼叫可用鏡頭前發生錯誤
   WidgetsFlutterBinding.ensureInitialized();
-  final cameras = await availableCameras();
-  runApp(MyApp(cameras: cameras));
+
+  List<CameraDescription> cameras = const <CameraDescription>[];
+  String? cameraError;
+
+  try {
+    cameras = await availableCameras();
+  } catch (error) {
+    cameraError = '無法初始化相機：$error';
+  }
+
+  runApp(MyApp(
+    initialCameras: cameras,
+    initialCameraError: cameraError,
+  ));
 }
 
-class MyApp extends StatelessWidget {
-  final List<CameraDescription> cameras;
-  const MyApp({super.key, required this.cameras});
+/// 應用程式入口：維持 StatefulWidget 以便在相機初始化失敗時允許重新嘗試
+class MyApp extends StatefulWidget {
+  final List<CameraDescription> initialCameras; // 啟動階段取得的鏡頭清單
+  final String? initialCameraError; // 啟動時的錯誤訊息
+
+  const MyApp({
+    super.key,
+    required this.initialCameras,
+    this.initialCameraError,
+  });
+
+  @override
+  State<MyApp> createState() => _MyAppState();
+}
+
+class _MyAppState extends State<MyApp> {
+  // ---------- 狀態管理區 ----------
+  late List<CameraDescription> _cameras; // 最新的鏡頭清單
+  String? _cameraError; // 最近一次的錯誤資訊
+  bool _isLoading = false; // 控制是否顯示載入指示
+
+  @override
+  void initState() {
+    super.initState();
+    _cameras = widget.initialCameras;
+    _cameraError = widget.initialCameraError;
+  }
+
+  // ---------- 方法區 ----------
+  /// 重新嘗試載入鏡頭，於使用者按下重新整理時呼叫
+  Future<void> _reloadCameras() async {
+    setState(() {
+      _isLoading = true;
+      _cameraError = null;
+    });
+
+    try {
+      final cameras = await availableCameras();
+      if (!mounted) return;
+      setState(() {
+        _cameras = cameras;
+        _isLoading = false;
+      });
+    } catch (error) {
+      if (!mounted) return;
+      setState(() {
+        _cameraError = '無法初始化相機：$error';
+        _isLoading = false;
+      });
+    }
+  }
 
   @override
   Widget build(BuildContext context) {
     return MaterialApp(
       title: 'Golf App',
-      home: RecorderPage(cameras: cameras),
+      theme: ThemeData(
+        colorScheme: ColorScheme.fromSeed(seedColor: const Color(0xFF1E8E5A)),
+        scaffoldBackgroundColor: const Color(0xFFF5F7FB),
+        useMaterial3: true,
+      ),
+      home: _buildHome(),
     );
   }
-}
 
-class RecorderPage extends StatefulWidget {
-  final List<CameraDescription> cameras;
-  const RecorderPage({super.key, required this.cameras});
-
-  @override
-  State<RecorderPage> createState() => _RecorderPageState();
-}
-
-class _RecorderPageState extends State<RecorderPage> {
-  CameraController? controller;
-  bool isRecording = false;
-  double maxDb = -160;
-  List<double> waveform = [];
-  List<double> waveformAccumulated = [];
-  double score = 0;
-  final ValueNotifier<int> repaintNotifier = ValueNotifier(0);
-
-  final FlutterAudioCapture _audioCapture = FlutterAudioCapture();
-  late Isolate _isolate;
-  ReceivePort? _receivePort;
-
-  //StreamSubscription? volumeButtonListener;
-  final AssetsAudioPlayer _audioPlayer = AssetsAudioPlayer();
-  final MethodChannel _volumeChannel = MethodChannel('volume_button_channel');
-  bool _isCountingDown = false;
-
-  @override
-  void initState() {
-    super.initState();
-    init();
-    initVolumeKeyListener();
-  }
-
-  void initVolumeKeyListener() {
-    _volumeChannel.setMethodCallHandler((call) async {
-      if (call.method == 'volume_down') {
-        if (!_isCountingDown && !isRecording) {
-          _isCountingDown = true;
-          await playCountdownAndStart();
-          _isCountingDown = false;
-        }
-      }
-    });
-  }
-
-  /// 播放倒數音檔並等待播放完成
-  Future<void> _playCountdown() async {
-    await _audioPlayer.open(
-      Audio('assets/sounds/1.mp3'),
-      autoStart: true,
-      showNotification: false,
-    );
-    // 監聽播放完成事件，確保倒數音檔播放完畢
-    await _audioPlayer.playlistFinished.first;
-  }
-
-  /// 進行單次錄影流程
-  Future<void> _recordOnce(int index) async {
-    try {
-      waveformAccumulated.clear();
-      await initAudioCapture();
-      await controller!.startVideoRecording();
-
-      // 預設錄影 15 秒
-      await Future.delayed(Duration(seconds: 15));
-
-      final XFile videoFile = await controller!.stopVideoRecording();
-      await _audioCapture.stop();
-      _receivePort?.close();
-      _isolate.kill(priority: Isolate.immediate);
-
-      // 以 run 序號與時間戳作為檔名
-      final directory = Directory('/storage/emulated/0/Download');
-      if (!await directory.exists()) {
-        await directory.create(recursive: true);
-      }
-      final timestamp = DateTime.now().millisecondsSinceEpoch;
-      final newPath = '${directory.path}/run_${index + 1}_$timestamp.mp4';
-      await File(videoFile.path).copy(newPath);
-      debugPrint('✅ 儲存為 run_${index + 1}_$timestamp.mp4'); // 記錄成功儲存的檔案資訊
-    } catch (e) {
-      debugPrint('❌ 錄影時出錯：$e'); // 記錄錯誤以利除錯
-    }
-  }
-
-  /// 按一次後自動執行五次倒數與錄影
-  /// 每次錄影結束後會休息 10 秒再進行下一球
-  Future<void> playCountdownAndStart() async {
-    setState(() => isRecording = true);
-    for (int i = 0; i < 5; i++) {
-      if (i == 1) {
-        var duration = const Duration(seconds: 8);
-        // 改用非阻塞延遲，避免 UI 卡頓
-        await Future.delayed(duration);
-      }
-      // 倒數音檔播放完畢後才開始錄影
-      await _playCountdown();
-      var duration = const Duration(seconds: 3);
-      // 改用非阻塞延遲，避免 UI 卡頓
-      await Future.delayed(duration);
-      await _recordOnce(i);
-      // 打完一球後休息 10 秒，再進入下一次循環
-      if (i < 4) {
-        await Future.delayed(const Duration(seconds: 10));
-      }
-    }
-    setState(() => isRecording = false);
-  }
-
-  Future<void> pickAndPlayVideo() async {
-    final result = await FilePicker.platform.pickFiles(
-      type: FileType.video,
-      initialDirectory: '/storage/emulated/0/Download',
-    );
-
-    // 若元件已卸載則不再使用 context 避免錯誤
-    if (!mounted) return;
-
-    if (result != null && result.files.single.path != null) {
-      final filePath = result.files.single.path!;
-      Navigator.push(
-        context,
-        MaterialPageRoute(builder: (_) => VideoPlayerPage(videoPath: filePath)),
+  /// 依照載入狀態顯示登入頁、錯誤提示或載入指示
+  Widget _buildHome() {
+    if (_isLoading) {
+      return const Scaffold(
+        body: Center(child: CircularProgressIndicator()),
       );
     }
-  }
 
-  Future<void> init() async {
-    await Permission.camera.request();
-    await Permission.microphone.request();
-    await Permission.storage.request();
-
-    controller = CameraController(
-      widget.cameras.first,
-      ResolutionPreset.medium,
-    );
-    await controller!.initialize();
-    setState(() {});
-  }
-
-  Future<void> initAudioCapture() async {
-    try {
-      _receivePort = ReceivePort();
-      _receivePort!.listen((data) {
-        if (data is List<double>) {
-          waveform = data;
-          waveformAccumulated.addAll(data);
-
-          final double avg =
-              waveform.fold(0.0, (prev, el) => prev + el.abs()) /
-              waveform.length;
-          final double stdev = math.sqrt(
-            waveform
-                    .map((e) => math.pow(e.abs() - avg, 2))
-                    .reduce((a, b) => a + b) /
-                waveform.length,
-          );
-          final double focus = avg / (stdev + 1e-6);
-          score = (focus / (focus + 1)).clamp(0.0, 1.0);
-
-          repaintNotifier.value++;
-        }
-      });
-      _isolate = await Isolate.spawn(
-        _audioProcessingIsolate,
-        _receivePort!.sendPort,
-      );
-      await _audioCapture.init();
-      await _audioCapture.start(
-        (data) => _receivePort?.sendPort.send(
-          List<double>.from((data as List).map((e) => e as double)),
-        ),
-        onError,
-        sampleRate: 22050,
-        bufferSize: 512,
-      );
-    } catch (e) {
-      log('🎙️ 初始化失敗: $e');
-      rethrow;
-    }
-  }
-
-  Map<String, dynamic> analyzeCrispness(List<double> data, int sampleRate) {
-    final frameSize = (0.1 * sampleRate).toInt(); // 每100ms
-    final hopSize = frameSize;
-
-    double maxScore = 0;
-    int maxIndex = 0;
-
-    for (int i = 0; i + frameSize <= data.length; i += hopSize) {
-      final frame = data.sublist(i, i + frameSize);
-
-      // 計算 Zero Crossing Rate
-      int zeroCross = 0;
-      for (int j = 1; j < frame.length; j++) {
-        if ((frame[j - 1] >= 0 && frame[j] < 0) ||
-            (frame[j - 1] < 0 && frame[j] >= 0)) {
-          zeroCross++;
-        }
-      }
-
-      final zcr = zeroCross / frameSize;
-      if (zcr > maxScore) {
-        maxScore = zcr;
-        maxIndex = i;
-      }
-    }
-
-    double bestTime = maxIndex / sampleRate;
-
-    return {'score': (maxScore * 10).clamp(0.0, 10.0), 'timestamp': bestTime};
-  }
-
-  static void _audioProcessingIsolate(SendPort sendPort) {}
-
-  void onError(Object e) {
-    log("❌ Audio Capture Error: $e");
-  }
-  // 原本的 start/stop 流程已整合至 _recordOnce
-
-  @override
-  void dispose() {
-    controller?.dispose();
-    _audioCapture.stop();
-    _receivePort?.close();
-    _isolate.kill(priority: Isolate.immediate);
-    super.dispose();
-    _audioPlayer.dispose();
-  }
-
-  @override
-  Widget build(BuildContext context) {
-    if (controller == null || !controller!.value.isInitialized) {
-      return Scaffold(body: Center(child: CircularProgressIndicator()));
-    }
-
-    return Scaffold(
-      appBar: AppBar(title: Text('Golf Recorder')),
-      body: Stack(
-        children: [
-          Column(
-            children: [
-              Expanded(child: CameraPreview(controller!)),
-              SizedBox(
-                height: 200,
-                width: double.infinity,
-                child: WaveformWidget(
-                  waveformAccumulated: List.from(waveformAccumulated),
-                  repaintNotifier: repaintNotifier,
+    if (_cameraError != null) {
+      return Scaffold(
+        body: Center(
+          child: Padding(
+            padding: const EdgeInsets.all(24),
+            child: Column(
+              mainAxisSize: MainAxisSize.min,
+              children: [
+                Text(
+                  _cameraError!,
+                  textAlign: TextAlign.center,
+                  style: const TextStyle(fontSize: 16, color: Colors.redAccent),
                 ),
-              ),
-              // 移除結束評分顯示
-            ],
-          ),
-          Positioned(
-            bottom: 20,
-            right: 20,
-            child: ElevatedButton(
-              onPressed: isRecording ? null : playCountdownAndStart,
-              child: Text(isRecording ? '錄製中...' : '開始錄製'),
+                const SizedBox(height: 16),
+                FilledButton(
+                  onPressed: _reloadCameras,
+                  child: const Text('重新嘗試'),
+                ),
+              ],
             ),
           ),
-          Positioned(
-            bottom: 20,
-            left: 20,
-            child: ElevatedButton(
-              onPressed: pickAndPlayVideo,
-              child: Text('播放影片'),
-            ),
-          ),
-        ],
-      ),
-    );
-  }
-}
-
-class WaveformWidget extends StatelessWidget {
-  final List<double> waveformAccumulated;
-  final ValueNotifier<int> repaintNotifier;
-  const WaveformWidget({
-    super.key,
-    required this.waveformAccumulated,
-    required this.repaintNotifier,
-  });
-
-  @override
-  Widget build(BuildContext context) {
-    return ValueListenableBuilder<int>(
-      valueListenable: repaintNotifier,
-      builder: (context, value, child) {
-        return CustomPaint(
-          size: Size.infinite,
-          painter: WaveformPainter(List.from(waveformAccumulated)),
-        );
-      },
-    );
-  }
-}
-
-class WaveformPainter extends CustomPainter {
-  final List<double> waveform;
-  WaveformPainter(this.waveform);
-
-  @override
-  void paint(Canvas canvas, Size size) {
-    final paint = Paint()
-      ..color = Colors.blue
-      ..strokeWidth = 1.0;
-
-    if (waveform.isEmpty) return;
-
-    final double middle = size.height / 2;
-    final int maxSamples = size.width.toInt();
-    final int skip = waveform.length ~/ maxSamples;
-    if (skip == 0) return;
-
-    for (int i = 0; i < maxSamples; i++) {
-      final int idx = i * skip;
-      if (idx >= waveform.length) break;
-      final double x = i.toDouble();
-      final double y = middle - waveform[idx] * 500;
-      canvas.drawLine(Offset(x, middle), Offset(x, y), paint);
-    }
-  }
-
-  @override
-  bool shouldRepaint(covariant CustomPainter oldDelegate) => true;
-}
-
-class VideoPlayerPage extends StatefulWidget {
-  final String videoPath;
-  const VideoPlayerPage({super.key, required this.videoPath});
-
-  @override
-  State<VideoPlayerPage> createState() => _VideoPlayerPageState();
-}
-
-class _VideoPlayerPageState extends State<VideoPlayerPage> {
-  late VideoPlayerController _videoController;
-
-  @override
-  void initState() {
-    super.initState();
-    _videoController = VideoPlayerController.file(File(widget.videoPath))
-      ..initialize().then((_) {
-        setState(() {});
-        _videoController.play();
-      });
-  }
-
-  @override
-  void dispose() {
-    _videoController.dispose();
-    super.dispose();
-  }
-
-  @override
-  Widget build(BuildContext context) {
-    return Scaffold(
-      appBar: AppBar(title: Text('影片播放')),
-      body: Center(
-        child: _videoController.value.isInitialized
-            ? AspectRatio(
-                aspectRatio: _videoController.value.aspectRatio,
-                child: VideoPlayer(_videoController),
-              )
-            : CircularProgressIndicator(),
-      ),
-      floatingActionButton: FloatingActionButton(
-        onPressed: () {
-          setState(() {
-            _videoController.value.isPlaying
-                ? _videoController.pause()
-                : _videoController.play();
-          });
-        },
-        child: Icon(
-          _videoController.value.isPlaying ? Icons.pause : Icons.play_arrow,
         ),
-      ),
-    );
+      );
+    }
+
+    return LoginPage(cameras: _cameras);
   }
 }

--- a/lib/models/recording_history_entry.dart
+++ b/lib/models/recording_history_entry.dart
@@ -1,0 +1,130 @@
+import 'package:flutter/foundation.dart';
+
+/// 記錄單次錄影完成後的資料，方便首頁與歷史列表顯示
+@immutable
+class RecordingHistoryEntry {
+  /// 錄影檔案儲存的完整路徑
+  final String filePath;
+
+  /// 第幾輪錄影完成，從 1 開始編號
+  final int roundIndex;
+
+  /// 錄影完成的時間戳記，提供排序與顯示
+  final DateTime recordedAt;
+
+  /// 本輪錄影的設定秒數，供提示與說明使用
+  final int durationSeconds;
+
+  /// 是否在錄影當下有連線 IMU，可用於顯示模式標籤
+  final bool imuConnected;
+
+  /// 允許使用者自訂的影片名稱，空字串視為未命名
+  final String? customName;
+
+  /// 對應本輪錄影的 IMU 原始資料 CSV 清單（deviceId -> 路徑）
+  final Map<String, String> imuCsvPaths;
+
+  /// 影片縮圖的完整路徑，供首頁與歷史頁顯示預覽畫面
+  final String? thumbnailPath;
+
+  const RecordingHistoryEntry({
+    required this.filePath,
+    required this.roundIndex,
+    required this.recordedAt,
+    required this.durationSeconds,
+    required this.imuConnected,
+    this.customName,
+    this.imuCsvPaths = const {},
+    this.thumbnailPath,
+  });
+
+  /// 建立更新後的新實例，方便調整時長或其他欄位
+  RecordingHistoryEntry copyWith({
+    String? filePath,
+    int? roundIndex,
+    DateTime? recordedAt,
+    int? durationSeconds,
+    bool? imuConnected,
+    String? customName,
+    Map<String, String>? imuCsvPaths,
+    String? thumbnailPath,
+  }) {
+    return RecordingHistoryEntry(
+      filePath: filePath ?? this.filePath,
+      roundIndex: roundIndex ?? this.roundIndex,
+      recordedAt: recordedAt ?? this.recordedAt,
+      durationSeconds: durationSeconds ?? this.durationSeconds,
+      imuConnected: imuConnected ?? this.imuConnected,
+      customName: customName ?? this.customName,
+      imuCsvPaths: imuCsvPaths ?? this.imuCsvPaths,
+      thumbnailPath: thumbnailPath ?? this.thumbnailPath,
+    );
+  }
+
+  /// 提供統一的顯示標題，例如「第 3 輪錄影」
+  String get displayTitle {
+    final name = customName?.trim();
+    if (name != null && name.isNotEmpty) {
+      return name;
+    }
+    return '第\u0020${roundIndex}\u0020輪錄影';
+  }
+
+  /// 依據是否連線 IMU 回傳中文標籤，顯示當時的錄影模式
+  String get modeLabel => imuConnected ? '含 IMU 資料' : '純錄影';
+
+  /// 取得檔案名稱，透過正規式切割避免不同系統分隔符差異
+  String get fileName {
+    final segments = filePath.split(RegExp(r'[\\/]'));
+    return segments.isNotEmpty ? segments.last : filePath;
+  }
+
+  /// 回傳所有 CSV 檔名，方便列表顯示或除錯
+  List<String> get csvFileNames => imuCsvPaths.values
+      .map((path) => path.split(RegExp(r'[\\/]')).last)
+      .toList();
+
+  /// 是否有對應的感測資料可供下載
+  bool get hasImuCsv => imuCsvPaths.isNotEmpty;
+
+  /// 將資料轉為 JSON，方便持久化儲存與還原
+  Map<String, dynamic> toJson() {
+    return {
+      'filePath': filePath,
+      'roundIndex': roundIndex,
+      'recordedAt': recordedAt.toIso8601String(),
+      'durationSeconds': durationSeconds,
+      'imuConnected': imuConnected,
+      'customName': customName,
+      'imuCsvPaths': imuCsvPaths,
+      'thumbnailPath': thumbnailPath,
+    };
+  }
+
+  /// 從 JSON 還原歷史紀錄，並對缺漏欄位提供預設值
+  factory RecordingHistoryEntry.fromJson(Map<String, dynamic> json) {
+    final rawCsv = json['imuCsvPaths'];
+    final parsedCsv = <String, String>{};
+    if (rawCsv is Map) {
+      // 將任何型別的鍵值轉為字串，避免類型不一致導致轉換失敗
+      rawCsv.forEach((key, value) {
+        parsedCsv[key.toString()] = value?.toString() ?? '';
+      });
+    }
+
+    final rawThumbnail = (json['thumbnailPath'] as String?)?.trim();
+
+    return RecordingHistoryEntry(
+      filePath: (json['filePath'] as String?) ?? '',
+      roundIndex: (json['roundIndex'] as int?) ?? 1,
+      recordedAt: DateTime.tryParse(json['recordedAt'] as String? ?? '') ??
+          DateTime.now(),
+      durationSeconds: (json['durationSeconds'] as int?) ?? 0,
+      imuConnected: (json['imuConnected'] as bool?) ?? false,
+      customName: (json['customName'] as String?) ?? '',
+      imuCsvPaths: parsedCsv,
+      thumbnailPath:
+          rawThumbnail == null || rawThumbnail.isEmpty ? null : rawThumbnail,
+    );
+  }
+}

--- a/lib/pages/home_page.dart
+++ b/lib/pages/home_page.dart
@@ -1,0 +1,1684 @@
+import 'dart:async';
+import 'dart:convert'; // 匯入文字編碼與換行工具，解析 CSV 時需要用到
+import 'dart:io';
+import 'dart:math' as math;
+
+import 'package:camera/camera.dart';
+import 'package:flutter/foundation.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+
+import '../models/recording_history_entry.dart';
+import '../recorder_page.dart';
+import '../services/imu_data_logger.dart';
+import '../services/recording_history_storage.dart';
+import 'recording_history_page.dart';
+import 'recording_session_page.dart';
+
+/// 錄影卡片支援的操作種類
+enum _HistoryAction { rename, editDuration, delete }
+
+/// 首頁提供完整儀表板，呈現揮桿統計、影片庫與分析摘要
+class HomePage extends StatefulWidget {
+  final String userEmail; // 使用者登入後的電子郵件
+  final List<CameraDescription> cameras; // 傳入鏡頭資訊供後續錄影使用
+
+  const HomePage({super.key, required this.userEmail, required this.cameras});
+
+  @override
+  State<HomePage> createState() => _HomePageState();
+}
+
+class _HomePageState extends State<HomePage> {
+  // ---------- 狀態管理區 ----------
+  int _currentIndex = 2; // 底部導覽預設聚焦在 Quick Start
+  final List<RecordingHistoryEntry> _recordingHistory = []; // 首頁內部維護的錄影紀錄
+  bool _isHistoryLoading = true; // 控制歷史載入狀態，避免 UI 閃爍
+  int _practiceCount = 0; // 累積練習次數
+  double? _averageSpeedMph; // 估算出的平均揮桿速度（MPH）
+  double? _bestSpeedMph; // 歷史紀錄中的最佳揮桿速度
+  double? _consistencyScore; // 揮桿穩定度（0-1）
+  double? _impactClarity; // 擊球清脆度（0-1）
+  double? _sweetSpotPercentage; // 甜蜜點命中率百分比
+  bool _isMetricCalculating = false; // 是否正在重新計算儀表板數值
+  _ComparisonSnapshot? _comparisonBefore; // 比較區塊的上一筆紀錄
+  _ComparisonSnapshot? _comparisonAfter; // 比較區塊的最新紀錄
+
+  @override
+  void initState() {
+    super.initState();
+    _loadInitialHistory();
+  }
+
+  /// 將時間轉換為比較區塊顯示的日期文字（例：05/21）
+  String _formatComparisonDate(DateTime dateTime) {
+    return '${dateTime.month.toString().padLeft(2, '0')}/${dateTime.day.toString().padLeft(2, '0')}';
+  }
+
+  /// 建立比較區塊，呈現最新與上一筆揮桿的差異
+  Widget _buildComparisonCard() {
+    final before = _comparisonBefore;
+    final after = _comparisonAfter;
+    final analyzing = _isMetricCalculating;
+
+    // ---------- 內部小工具：負責產生顯示文字 ----------
+    String buildSpeedLabel(_ComparisonSnapshot? snapshot) {
+      if (analyzing) return '分析中...';
+      if (snapshot?.speedMph != null) {
+        return '${snapshot!.speedMph!.toStringAsFixed(1)} MPH';
+      }
+      return snapshot == null ? '--' : '無速度資訊';
+    }
+
+    String buildSubtitle(_ComparisonSnapshot? snapshot) {
+      if (analyzing) return '資料整理中';
+      if (snapshot == null) {
+        return '完成更多錄影即可生成比較';
+      }
+      final dateLabel = _formatComparisonDate(snapshot.entry.recordedAt);
+      final impactLabel = '${(snapshot.impactClarity * 100).clamp(0, 100).toStringAsFixed(0)}%';
+      return '$dateLabel  •  $impactLabel';
+    }
+
+    return Container(
+      padding: const EdgeInsets.all(20),
+      decoration: BoxDecoration(
+        color: Colors.white,
+        borderRadius: BorderRadius.circular(22),
+        boxShadow: const [
+          BoxShadow(color: Colors.black12, blurRadius: 8, offset: Offset(0, 4)),
+        ],
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          _SectionHeader(
+            title: 'Comparison',
+            actionLabel: '查看歷史',
+            onTap: _openRecordingHistoryPage,
+          ),
+          const SizedBox(height: 12),
+          Row(
+            children: [
+              Expanded(
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    const Text('Before', style: TextStyle(color: Color(0xFF7D8B9A))),
+                    const SizedBox(height: 6),
+                    Text(
+                      buildSpeedLabel(before),
+                      style: const TextStyle(
+                        fontSize: 20,
+                        fontWeight: FontWeight.bold,
+                        color: Color(0xFFDA4E5D),
+                      ),
+                    ),
+                    const SizedBox(height: 4),
+                    Text(
+                      buildSubtitle(before),
+                      style: const TextStyle(color: Color(0xFF7D8B9A)),
+                    ),
+                  ],
+                ),
+              ),
+              Container(
+                height: 80,
+                width: 1,
+                color: const Color(0xFFE4E8F0),
+              ),
+              Expanded(
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    const Text('After', style: TextStyle(color: Color(0xFF7D8B9A))),
+                    const SizedBox(height: 6),
+                    Text(
+                      buildSpeedLabel(after),
+                      style: const TextStyle(
+                        fontSize: 20,
+                        fontWeight: FontWeight.bold,
+                        color: Color(0xFF1E8E5A),
+                      ),
+                    ),
+                    const SizedBox(height: 4),
+                    Text(
+                      buildSubtitle(after),
+                      style: const TextStyle(color: Color(0xFF7D8B9A)),
+                    ),
+                  ],
+                ),
+              ),
+            ],
+          ),
+          const SizedBox(height: 16),
+          ElevatedButton(
+            onPressed: () => _onBottomNavTap(2),
+            style: ElevatedButton.styleFrom(
+              backgroundColor: const Color(0xFF1E8E5A),
+              padding: const EdgeInsets.symmetric(vertical: 14),
+              shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(16)),
+            ),
+            child: const Text('立即開始錄影'),
+          ),
+        ],
+      ),
+    );
+  }
+
+  // ---------- 方法區 ----------
+  /// 建立統計資訊卡片，方便重複使用與維持一致風格
+  Widget _buildStatCard({
+    required String title,
+    required String value,
+    required String subTitle,
+    required Color highlightColor,
+  }) {
+    return Container(
+      padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 14),
+      decoration: BoxDecoration(
+        color: Colors.white,
+        borderRadius: BorderRadius.circular(18),
+        boxShadow: const [
+          BoxShadow(color: Colors.black12, blurRadius: 8, offset: Offset(0, 4)),
+        ],
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Text(title, style: const TextStyle(fontSize: 13, color: Color(0xFF7D8B9A))),
+          const SizedBox(height: 6),
+          Text(
+            value,
+            style: TextStyle(
+              fontSize: 20,
+              fontWeight: FontWeight.bold,
+              color: highlightColor,
+            ),
+          ),
+          const SizedBox(height: 2),
+          Text(subTitle, style: const TextStyle(fontSize: 13, color: Color(0xFF1E1E1E))),
+        ],
+      ),
+    );
+  }
+
+  /// 建立影片縮圖方塊，將最新錄影資訊轉換為設計稿風格
+  Widget _buildVideoTile({
+    required RecordingHistoryEntry entry,
+    required Color baseColor,
+  }) {
+    // ---------- 字串組裝區 ----------
+    final recordedAt = entry.recordedAt;
+    final dateLabel = '${recordedAt.month.toString().padLeft(2, '0')}/${recordedAt.day.toString().padLeft(2, '0')}';
+    final durationLabel = '時長 ${entry.durationSeconds} 秒';
+    final modeLabel = entry.modeLabel;
+    final thumbnailPath = entry.thumbnailPath;
+    final hasThumbnail = thumbnailPath != null && thumbnailPath.isNotEmpty;
+
+    return Padding(
+      padding: const EdgeInsets.only(right: 16),
+      child: SizedBox(
+        width: 140,
+        child: Material(
+          color: Colors.transparent,
+          borderRadius: BorderRadius.circular(18),
+          child: InkWell(
+            borderRadius: BorderRadius.circular(18),
+            onTap: () => _playHistoryEntry(entry),
+            child: Ink(
+              decoration: BoxDecoration(
+                borderRadius: BorderRadius.circular(18),
+                gradient: LinearGradient(
+                  colors: [baseColor, baseColor.withOpacity(0.7)],
+                  begin: Alignment.topLeft,
+                  end: Alignment.bottomRight,
+                ),
+                boxShadow: const [
+                  BoxShadow(color: Colors.black26, blurRadius: 6, offset: Offset(0, 4)),
+                ],
+              ),
+              child: ClipRRect(
+                borderRadius: BorderRadius.circular(18),
+                child: Stack(
+                  children: [
+                    Positioned.fill(
+                      child: hasThumbnail
+                          ? Image.file(
+                              File(thumbnailPath),
+                              fit: BoxFit.cover,
+                              errorBuilder: (_, __, ___) {
+                                return DecoratedBox(
+                                  decoration: BoxDecoration(
+                                    gradient: LinearGradient(
+                                      colors: [baseColor.withOpacity(0.95), baseColor.withOpacity(0.55)],
+                                      begin: Alignment.bottomLeft,
+                                      end: Alignment.topRight,
+                                    ),
+                                  ),
+                                );
+                              },
+                            )
+                          : DecoratedBox(
+                              decoration: BoxDecoration(
+                                gradient: LinearGradient(
+                                  colors: [baseColor.withOpacity(0.95), baseColor.withOpacity(0.55)],
+                                  begin: Alignment.bottomLeft,
+                                  end: Alignment.topRight,
+                                ),
+                              ),
+                            ),
+                    ),
+                    Positioned.fill(
+                      child: DecoratedBox(
+                        decoration: BoxDecoration(
+                          gradient: LinearGradient(
+                            colors: [Colors.black.withOpacity(0.65), Colors.transparent],
+                            begin: Alignment.bottomCenter,
+                            end: Alignment.topCenter,
+                          ),
+                        ),
+                        child: const Align(
+                          alignment: Alignment.center,
+                          child: Icon(Icons.play_circle_fill, size: 46, color: Colors.white24),
+                        ),
+                      ),
+                    ),
+                    Positioned(
+                      left: 12,
+                      right: 12,
+                      bottom: 12,
+                      child: Column(
+                        crossAxisAlignment: CrossAxisAlignment.start,
+                        children: [
+                          Text(dateLabel, style: const TextStyle(color: Colors.white70, fontSize: 12)),
+                          const SizedBox(height: 4),
+                          Text(
+                            entry.displayTitle,
+                            style: const TextStyle(
+                              color: Colors.white,
+                              fontWeight: FontWeight.bold,
+                              fontSize: 16,
+                            ),
+                          ),
+                          const SizedBox(height: 2),
+                          Text(
+                            '$modeLabel｜$durationLabel',
+                            style: const TextStyle(color: Colors.white70, fontSize: 12, height: 1.2),
+                          ),
+                        ],
+                      ),
+                    ),
+                    Positioned(
+                      top: 6,
+                      right: 6,
+                      child: PopupMenuButton<_HistoryAction>(
+                        tooltip: '更多操作',
+                        icon: const Icon(Icons.more_vert, color: Colors.white70),
+                        color: Colors.white,
+                        onSelected: (action) {
+                          // 使用 addPostFrameCallback 讓操作在下一幀進行，確保 PopupMenu 已完整關閉
+                          WidgetsBinding.instance.addPostFrameCallback((_) {
+                            switch (action) {
+                              case _HistoryAction.rename:
+                                _renameHistoryEntry(entry);
+                                break;
+                              case _HistoryAction.editDuration:
+                                _editHistoryDuration(entry);
+                                break;
+                              case _HistoryAction.delete:
+                                _deleteHistoryEntry(entry);
+                                break;
+                            }
+                          });
+                        },
+                        itemBuilder: (context) => [
+                          const PopupMenuItem<_HistoryAction>(
+                            value: _HistoryAction.rename,
+                            child: Text('重新命名'),
+                          ),
+                          const PopupMenuItem<_HistoryAction>(
+                            value: _HistoryAction.editDuration,
+                            child: Text('調整時長'),
+                          ),
+                          const PopupMenuItem<_HistoryAction>(
+                            value: _HistoryAction.delete,
+                            child: Text('刪除影片'),
+                          ),
+                        ],
+                      ),
+                    ),
+                  ],
+                ),
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+
+  /// 將儀表板數值轉換為雷達圖比例，便於統一控制上限
+  List<double> _buildRadarValues() {
+    final averageSpeedScore = _averageSpeedMph != null
+        ? (_averageSpeedMph! / 120).clamp(0.0, 1.0)
+        : 0.0;
+    final bestSpeedScore = _bestSpeedMph != null
+        ? (_bestSpeedMph! / 130).clamp(0.0, 1.0)
+        : averageSpeedScore;
+    final stabilityScore = (_consistencyScore ?? 0).clamp(0.0, 1.0);
+    final clarityScore = (_impactClarity ??
+            (_sweetSpotPercentage != null ? _sweetSpotPercentage! / 100 : 0))
+        .clamp(0.0, 1.0);
+    final volumeScore = (_practiceCount / 12).clamp(0.0, 1.0);
+
+    return [averageSpeedScore, stabilityScore, clarityScore, bestSpeedScore, volumeScore];
+  }
+
+  /// 載入既有錄影歷史，確保重新開啟 App 仍可看到舊資料
+  Future<void> _loadInitialHistory() async {
+    final entries = await RecordingHistoryStorage.instance.loadHistory();
+    final regenerated = await _cleanInvalidThumbnails(entries);
+    final finalEntries = regenerated ?? entries;
+
+    if (!mounted) return;
+    setState(() {
+      _recordingHistory
+        ..clear()
+        ..addAll(finalEntries);
+      _isHistoryLoading = false;
+      _practiceCount = finalEntries.length;
+    });
+
+    if (regenerated != null) {
+      unawaited(RecordingHistoryStorage.instance.saveHistory(finalEntries));
+    }
+
+    unawaited(_refreshDashboardMetrics());
+  }
+
+  /// 檢查縮圖檔案是否存在，若遺失則將欄位清空避免顯示破圖
+  Future<List<RecordingHistoryEntry>?> _cleanInvalidThumbnails(
+    List<RecordingHistoryEntry> entries,
+  ) async {
+    if (entries.isEmpty) {
+      return null; // 無資料時直接返回
+    }
+
+    final updated = <RecordingHistoryEntry>[];
+    var hasChanges = false;
+
+    for (final entry in entries) {
+      var thumbnailPath = entry.thumbnailPath;
+      final needsGenerate = thumbnailPath == null ||
+          thumbnailPath.isEmpty ||
+          !(await File(thumbnailPath).exists());
+
+      if (needsGenerate) {
+        // ---------- 縮圖清理說明 ----------
+        // 舊版紀錄可能沒有縮圖檔案，或檔案被手動刪除。此時直接清空欄位
+        // 讓 UI 顯示預設樣式，避免再度啟動會造成緩衝區警告的擷取流程。
+        thumbnailPath = null;
+      }
+
+      if (thumbnailPath != entry.thumbnailPath) {
+        hasChanges = true;
+      }
+
+      updated.add(entry.copyWith(thumbnailPath: thumbnailPath));
+    }
+
+    return hasChanges ? updated : null;
+  }
+
+  /// 刪除指定的歷史紀錄，並詢問是否同步移除實體檔案
+  Future<void> _deleteHistoryEntry(RecordingHistoryEntry entry) async {
+    if (_recordingHistory.isEmpty) {
+      return; // 無資料時直接略過
+    }
+
+    final shouldRemove = await showDialog<bool>(
+      context: context,
+      builder: (dialogContext) {
+        return AlertDialog(
+          title: const Text('刪除影片紀錄'),
+          content: Text('確定要刪除「${entry.displayTitle}」嗎？\n影片與對應 CSV 會一併從裝置移除。'),
+          actions: [
+            TextButton(
+              onPressed: () => Navigator.of(dialogContext).pop(false),
+              child: const Text('取消'),
+            ),
+            FilledButton(
+              onPressed: () => Navigator.of(dialogContext).pop(true),
+              child: const Text('刪除'),
+            ),
+          ],
+        );
+      },
+    );
+
+    if (shouldRemove != true) {
+      return; // 使用者取消刪除
+    }
+
+    final updatedEntries = List<RecordingHistoryEntry>.from(_recordingHistory)
+      ..removeWhere((item) =>
+          item.filePath == entry.filePath && item.recordedAt == entry.recordedAt);
+    if (updatedEntries.length == _recordingHistory.length) {
+      return; // 未找到對應項目
+    }
+
+    await _applyHistoryState(updatedEntries);
+    unawaited(_deleteEntryFiles(entry));
+
+    if (!mounted) return;
+    ScaffoldMessenger.of(context).showSnackBar(
+      SnackBar(content: Text('已刪除 ${entry.fileName}')), // 告知刪除完成
+    );
+  }
+
+  /// 顯示輸入框讓使用者重新命名影片
+  Future<void> _renameHistoryEntry(RecordingHistoryEntry entry) async {
+    final initialText = entry.customName != null && entry.customName!.trim().isNotEmpty
+        ? entry.customName!.trim()
+        : entry.displayTitle;
+    String tempName = initialText; // 暫存輸入內容，避免 TextEditingController 釋放問題
+    final formKey = GlobalKey<FormState>();
+    debugPrint('[首頁歷史] 準備重新命名影片：${entry.fileName}'); // 紀錄流程起點
+    final newName = await showDialog<String>(
+      context: context,
+      builder: (dialogContext) {
+        return AlertDialog(
+          title: const Text('重新命名影片'),
+          content: Form(
+            key: formKey,
+            autovalidateMode: AutovalidateMode.onUserInteraction,
+            child: TextFormField(
+              initialValue: initialText,
+              maxLength: 40,
+              decoration: const InputDecoration(
+                labelText: '影片名稱',
+                helperText: '可留空以恢復預設名稱',
+              ),
+              onChanged: (value) => tempName = value,
+              validator: (value) {
+                final trimmed = value?.trim() ?? '';
+                if (trimmed.length > 40) {
+                  return '名稱需在 40 字以內';
+                }
+                return null;
+              },
+            ),
+          ),
+          actions: [
+            TextButton(
+              onPressed: () => Navigator.of(dialogContext).pop(),
+              child: const Text('取消'),
+            ),
+            FilledButton(
+              onPressed: () {
+                final isValid = formKey.currentState?.validate() ?? false;
+                if (!isValid) {
+                  return; // 驗證失敗時不關閉視窗
+                }
+                Navigator.of(dialogContext).pop(tempName.trim());
+              },
+              child: const Text('儲存'),
+            ),
+          ],
+        );
+      },
+    );
+
+    if (!mounted || newName == null) {
+      debugPrint('[首頁歷史] 重新命名流程取消或頁面已卸載');
+      return;
+    }
+
+    final normalizedName = newName.trim();
+    final storedName = normalizedName.isEmpty ? '' : normalizedName;
+    final originalName = (entry.customName ?? '').trim();
+    debugPrint('[首頁歷史] 重新命名輸入：stored="$storedName" original="$originalName"');
+    if (storedName == originalName) {
+      debugPrint('[首頁歷史] 名稱未變更，終止重新命名流程');
+      return; // 未變更名稱時不進行後續流程
+    }
+
+    final updatedEntries = List<RecordingHistoryEntry>.from(_recordingHistory);
+    final targetIndex = updatedEntries.indexWhere((item) =>
+        item.filePath == entry.filePath && item.recordedAt == entry.recordedAt);
+    if (targetIndex == -1) {
+      debugPrint('[首頁歷史] 找不到對應紀錄，無法重新命名');
+      return;
+    }
+
+    final defaultTitle = entry.copyWith(customName: '').displayTitle;
+    updatedEntries[targetIndex] =
+        updatedEntries[targetIndex].copyWith(customName: storedName);
+    debugPrint('[首頁歷史] 套用重新命名至索引 $targetIndex，準備立即寫回狀態');
+    await _applyHistoryState(updatedEntries);
+
+    if (!mounted) return;
+    final snackMessage = storedName.isEmpty
+        ? '已恢復影片名稱為 $defaultTitle'
+        : '已將影片命名為 $storedName';
+    ScaffoldMessenger.of(context).showSnackBar(
+      SnackBar(content: Text(snackMessage)),
+    );
+  }
+
+  /// 顯示秒數輸入框，更新影片時長資訊
+  Future<void> _editHistoryDuration(RecordingHistoryEntry entry) async {
+    debugPrint('[首頁歷史] 準備調整影片時長：${entry.fileName} 當前秒數=${entry.durationSeconds}');
+    String tempValue = entry.durationSeconds.toString(); // 以字串暫存輸入內容
+    final formKey = GlobalKey<FormState>();
+    final newDuration = await showDialog<int>(
+      context: context,
+      builder: (dialogContext) {
+        return AlertDialog(
+          title: const Text('調整影片時長'),
+          content: Form(
+            key: formKey,
+            autovalidateMode: AutovalidateMode.onUserInteraction,
+            child: TextFormField(
+              initialValue: tempValue,
+              keyboardType: TextInputType.number,
+              inputFormatters: [FilteringTextInputFormatter.digitsOnly],
+              decoration: const InputDecoration(
+                labelText: '秒數',
+                helperText: '輸入影片實際秒數（正整數）',
+              ),
+              onChanged: (value) => tempValue = value,
+              validator: (value) {
+                final trimmed = value?.trim() ?? '';
+                final parsed = int.tryParse(trimmed);
+                if (parsed == null || parsed <= 0) {
+                  return '請輸入大於 0 的秒數';
+                }
+                return null;
+              },
+            ),
+          ),
+          actions: [
+            TextButton(
+              onPressed: () => Navigator.of(dialogContext).pop(),
+              child: const Text('取消'),
+            ),
+            FilledButton(
+              onPressed: () {
+                final isValid = formKey.currentState?.validate() ?? false;
+                if (!isValid) {
+                  return; // 驗證失敗時不關閉視窗
+                }
+                final parsed = int.parse(tempValue.trim());
+                Navigator.of(dialogContext).pop(parsed);
+              },
+              child: const Text('儲存'),
+            ),
+          ],
+        );
+      },
+    );
+
+    if (!mounted || newDuration == null) {
+      debugPrint('[首頁歷史] 調整時長流程取消或頁面已卸載');
+      return; // 使用者取消或未輸入
+    }
+
+    if (newDuration == entry.durationSeconds) {
+      debugPrint('[首頁歷史] 秒數未變更（$newDuration 秒），略過更新');
+      return; // 秒數未變更時不進行後續處理
+    }
+
+    final updatedEntries = List<RecordingHistoryEntry>.from(_recordingHistory);
+    final targetIndex = updatedEntries.indexWhere((item) =>
+        item.filePath == entry.filePath && item.recordedAt == entry.recordedAt);
+    if (targetIndex == -1) {
+      debugPrint('[首頁歷史] 找不到對應紀錄，無法更新時長');
+      return; // 未找到對應項目
+    }
+
+    updatedEntries[targetIndex] =
+        updatedEntries[targetIndex].copyWith(durationSeconds: newDuration);
+    debugPrint('[首頁歷史] 更新索引 $targetIndex 的時長為 $newDuration 秒，準備立即寫回狀態');
+    await _applyHistoryState(updatedEntries);
+
+    if (!mounted) return;
+    ScaffoldMessenger.of(context).showSnackBar(
+      SnackBar(content: Text('已更新 ${entry.displayTitle} 的時長為 $newDuration 秒')),
+    );
+  }
+
+  /// 移除影片與 CSV 實體檔案，避免資料殘留
+  Future<void> _deleteEntryFiles(RecordingHistoryEntry entry) async {
+    try {
+      final videoFile = File(entry.filePath);
+      if (await videoFile.exists()) {
+        await videoFile.delete();
+      }
+    } catch (_) {
+      // 保持靜默，避免 IO 例外影響主流程
+    }
+
+    final thumbnailPath = entry.thumbnailPath;
+    if (thumbnailPath != null && thumbnailPath.isNotEmpty) {
+      try {
+        final thumbFile = File(thumbnailPath);
+        if (await thumbFile.exists()) {
+          await thumbFile.delete();
+        }
+      } catch (_) {
+        // 縮圖刪除失敗時同樣忽略
+      }
+    }
+
+    for (final path in entry.imuCsvPaths.values) {
+      if (path.isEmpty) continue;
+      try {
+        final csvFile = File(path);
+        if (await csvFile.exists()) {
+          await csvFile.delete();
+        }
+      } catch (_) {
+        // 單筆刪除失敗可忽略
+      }
+    }
+  }
+
+  /// 處理底部導覽點擊，依據不同索引執行對應導覽
+  void _onBottomNavTap(int index) {
+    if (index == 2) {
+      Navigator.of(context).push(
+        MaterialPageRoute(
+          builder: (_) => RecorderPage(
+            cameras: widget.cameras,
+            initialHistory: _recordingHistory,
+            onHistoryChanged: _handleHistoryUpdated,
+          ),
+        ),
+      );
+      return;
+    }
+    if (index == 3) {
+      // 點選 Data Metrics 時直接導向錄影歷史頁，方便快速檢視過往紀錄
+      unawaited(_openRecordingHistoryPage());
+      setState(() => _currentIndex = index);
+      return;
+    }
+    setState(() => _currentIndex = index);
+  }
+
+  /// 將更新後的錄影紀錄套用到首頁狀態並觸發儲存與統計重算
+  Future<void> _applyHistoryState(List<RecordingHistoryEntry> entries) async {
+    if (!mounted) {
+      debugPrint('[首頁歷史] _applyHistoryState 略過：頁面已卸載');
+      return;
+    }
+
+    debugPrint('[首頁歷史] _applyHistoryState 套用 ${entries.length} 筆資料');
+    setState(() {
+      _recordingHistory
+        ..clear()
+        ..addAll(entries);
+      _isHistoryLoading = false;
+      _practiceCount = entries.length;
+      _isMetricCalculating = true;
+    });
+
+    await RecordingHistoryStorage.instance.saveHistory(
+      List<RecordingHistoryEntry>.from(_recordingHistory),
+    );
+
+    if (!mounted) {
+      debugPrint('[首頁歷史] 儲存完成時頁面已卸載，停止後續流程');
+      return;
+    }
+
+    await _refreshDashboardMetrics();
+  }
+
+  /// 接收錄影頁回傳的歷史紀錄，統一整理後套用到首頁狀態
+  void _handleHistoryUpdated(List<RecordingHistoryEntry> entries) {
+    unawaited(_prepareHistoryUpdate(entries));
+  }
+
+  /// 先確保縮圖完整再寫回狀態，避免畫面顯示灰階背景
+  Future<void> _prepareHistoryUpdate(List<RecordingHistoryEntry> entries) async {
+    final regenerated = await _cleanInvalidThumbnails(entries);
+    await _applyHistoryState(regenerated ?? entries);
+  }
+
+  /// 重新計算首頁儀表板指標，將 IMU CSV 中的線性加速度與旋轉資訊轉為練習洞察
+  Future<void> _refreshDashboardMetrics() async {
+    final snapshot = List<RecordingHistoryEntry>.from(_recordingHistory);
+    if (snapshot.isEmpty) {
+      if (!mounted) return;
+      setState(() {
+        _isMetricCalculating = false;
+        _averageSpeedMph = null;
+        _bestSpeedMph = null;
+        _consistencyScore = null;
+        _impactClarity = null;
+        _sweetSpotPercentage = null;
+        _comparisonBefore = null;
+        _comparisonAfter = null;
+      });
+      return;
+    }
+
+    setState(() {
+      _isMetricCalculating = true;
+    });
+
+    try {
+      final metrics = await _MetricsCalculator.compute(snapshot);
+      if (!mounted) return;
+      setState(() {
+        _isMetricCalculating = false;
+        _averageSpeedMph = metrics.averageSpeedMph;
+        _bestSpeedMph = metrics.bestSpeedMph;
+        _consistencyScore = metrics.consistencyScore;
+        _impactClarity = metrics.averageImpactClarity;
+        _sweetSpotPercentage = metrics.sweetSpotPercentage;
+        _comparisonBefore = metrics.comparisonBefore;
+        _comparisonAfter = metrics.comparisonAfter;
+      });
+    } catch (e) {
+      if (!mounted) return;
+      setState(() {
+        _isMetricCalculating = false;
+        _averageSpeedMph = null;
+        _bestSpeedMph = null;
+        _consistencyScore = null;
+        _impactClarity = null;
+        _sweetSpotPercentage = null;
+        _comparisonBefore = null;
+        _comparisonAfter = null;
+      });
+    }
+  }
+
+  /// 開啟獨立的錄影歷史頁面，讓使用者專注瀏覽過往影片
+  Future<void> _openRecordingHistoryPage() async {
+    final result = await Navigator.of(context).push<List<RecordingHistoryEntry>>(
+      MaterialPageRoute(
+        builder: (_) => RecordingHistoryPage(entries: _recordingHistory),
+      ),
+    );
+    if (result != null) {
+      _handleHistoryUpdated(result);
+    }
+  }
+
+  /// 直接播放單筆歷史影片，並在檔案遺失時給予即時提示
+  Future<void> _playHistoryEntry(RecordingHistoryEntry entry) async {
+    final file = File(entry.filePath); // 建立檔案物件以檢查實際存在狀態
+    if (!await file.exists()) {
+      if (!mounted) return; // 若畫面已卸載則不再顯示訊息
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(content: Text('找不到影片檔案 ${entry.fileName}，請確認檔案是否仍保留於裝置中。')),
+      );
+      return;
+    }
+
+    if (!mounted) return;
+    await Navigator.of(context).push(
+      MaterialPageRoute(builder: (_) => VideoPlayerPage(videoPath: entry.filePath)),
+    );
+  }
+
+  /// 建立首頁的錄影歷史快捷卡片，提供統計資訊與導覽按鈕
+  Widget _buildHistoryShortcutCard() {
+    if (_isHistoryLoading) {
+      return Container(
+        padding: const EdgeInsets.all(20),
+        decoration: BoxDecoration(
+          color: Colors.white,
+          borderRadius: BorderRadius.circular(22),
+          boxShadow: const [
+            BoxShadow(color: Colors.black12, blurRadius: 10, offset: Offset(0, 5)),
+          ],
+        ),
+        child: const Center(
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              CircularProgressIndicator(),
+              SizedBox(height: 12),
+              Text('正在載入錄影歷史...', style: TextStyle(fontSize: 14)),
+            ],
+          ),
+        ),
+      );
+    }
+
+    final historyCount = _recordingHistory.length;
+    final latestEntry = historyCount > 0 ? _recordingHistory.first : null;
+
+    return Container(
+      padding: const EdgeInsets.all(20),
+      decoration: BoxDecoration(
+        color: Colors.white,
+        borderRadius: BorderRadius.circular(22),
+        boxShadow: const [
+          BoxShadow(color: Colors.black12, blurRadius: 10, offset: Offset(0, 5)),
+        ],
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Row(
+            children: [
+              Container(
+                padding: const EdgeInsets.all(10),
+                decoration: BoxDecoration(
+                  color: const Color(0xFF123B70),
+                  borderRadius: BorderRadius.circular(16),
+                ),
+                child: const Icon(Icons.video_library_rounded, color: Colors.white),
+              ),
+              const SizedBox(width: 14),
+              Expanded(
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    const Text(
+                      '錄影歷史',
+                      style: TextStyle(
+                        fontSize: 18,
+                        fontWeight: FontWeight.bold,
+                        color: Color(0xFF123B70),
+                      ),
+                    ),
+                    const SizedBox(height: 6),
+                    Text(
+                      historyCount > 0
+                          ? '已累積 $historyCount 筆紀錄，最新一筆是第 ${latestEntry!.roundIndex} 輪。'
+                          : '尚未有錄影紀錄，完成錄影後可於此快速檢視。',
+                      style: const TextStyle(fontSize: 13, color: Color(0xFF6F7B86), height: 1.4),
+                    ),
+                  ],
+                ),
+              ),
+            ],
+          ),
+          const SizedBox(height: 18),
+          FilledButton(
+            onPressed: _openRecordingHistoryPage,
+            style: FilledButton.styleFrom(
+              backgroundColor: const Color(0xFF1E8E5A),
+              padding: const EdgeInsets.symmetric(vertical: 14),
+              shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(16)),
+            ),
+            child: const Text(
+              '檢視完整錄影列表',
+              style: TextStyle(fontSize: 15, fontWeight: FontWeight.w600),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    // ---------- 假資料區（調整為歷史資料產生卡片） ----------
+    // 先以時間由新到舊排序，確保影片庫最左側即為最新成果
+    final sortedHistory = List<RecordingHistoryEntry>.from(_recordingHistory)
+      ..sort((a, b) => b.recordedAt.compareTo(a.recordedAt));
+    // 影片庫僅展示前六筆，避免水平列表超出視覺焦點
+    final displayedHistory = sortedHistory.take(6).toList(growable: false);
+    // 依序套用固定配色，讓卡片易於辨識錄影批次
+    const palette = <Color>[
+      Color(0xFF123B70),
+      Color(0xFF0A5E5A),
+      Color(0xFF4C2A9A),
+      Color(0xFF1E8E5A),
+      Color(0xFF2E8EFF),
+      Color(0xFF8E4AF4),
+    ];
+    // ---------- Analytics 動態字串區 ----------
+    final analyticsStatusLabel = _isMetricCalculating ? '分析中...' : '尚無資料';
+    final analyticsAvgSpeedText = _averageSpeedMph != null
+        ? '${_averageSpeedMph!.toStringAsFixed(1)} MPH'
+        : analyticsStatusLabel;
+    final analyticsBestSpeedText = _bestSpeedMph != null
+        ? '${_bestSpeedMph!.toStringAsFixed(1)} MPH'
+        : analyticsStatusLabel;
+    final analyticsStabilityText = _consistencyScore != null
+        ? '${(_consistencyScore!.clamp(0, 1) * 100).toStringAsFixed(0)} %'
+        : analyticsStatusLabel;
+    final analyticsSweetText = _sweetSpotPercentage != null
+        ? '${_sweetSpotPercentage!.clamp(0, 100).toStringAsFixed(0)} %'
+        : analyticsStatusLabel;
+    final analyticsClarityText = _impactClarity != null
+        ? '${(_impactClarity!.clamp(0, 1) * 100).toStringAsFixed(0)} %'
+        : analyticsStatusLabel;
+
+    return Scaffold(
+      backgroundColor: const Color(0xFFF5F7FB),
+      appBar: AppBar(
+        elevation: 0,
+        backgroundColor: const Color(0xFFF5F7FB),
+        toolbarHeight: 88,
+        automaticallyImplyLeading: false,
+        title: Row(
+          children: [
+            Container(
+              width: 42,
+              height: 42,
+              decoration: BoxDecoration(
+                color: const Color(0xFF1E8E5A),
+                borderRadius: BorderRadius.circular(14),
+              ),
+              child: const Icon(Icons.golf_course_rounded, color: Colors.white),
+            ),
+            const SizedBox(width: 16),
+            Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Text(
+                  'TekSwing',
+                  style: theme.textTheme.titleLarge?.copyWith(
+                    fontWeight: FontWeight.bold,
+                    color: const Color(0xFF0B2A2E),
+                  ),
+                ),
+                Text(
+                  widget.userEmail,
+                  style: theme.textTheme.bodyMedium?.copyWith(color: const Color(0xFF6E7B87)),
+                ),
+              ],
+            ),
+            const Spacer(),
+            IconButton(
+              onPressed: () {},
+              icon: const Icon(Icons.notifications_none_rounded, color: Color(0xFF0B2A2E)),
+            ),
+          ],
+        ),
+      ),
+      body: SingleChildScrollView(
+        padding: const EdgeInsets.symmetric(horizontal: 20, vertical: 8),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            LayoutBuilder(
+              builder: (context, constraints) {
+                // 始終維持同列呈現，窄螢幕改用橫向滑動避免卡片被擠壓
+                final practiceSubtitle = _practiceCount > 0
+                    ? '累積完成 $_practiceCount 次錄影'
+                    : '完成錄影後即可累積練習次數';
+                final speedValue = _isMetricCalculating
+                    ? '分析中...'
+                    : _averageSpeedMph != null
+                        ? '${_averageSpeedMph!.toStringAsFixed(1)} MPH'
+                        : '尚無資料';
+                final speedSubtitle = _isMetricCalculating
+                    ? '正在解析 IMU 感測紀錄'
+                    : _averageSpeedMph != null
+                        ? '依據含 IMU 的錄影推算揮桿速度'
+                        : '連線 IMU 錄影後即可取得數據';
+                final sweetValue = _isMetricCalculating
+                    ? '分析中...'
+                    : _sweetSpotPercentage != null
+                        ? '${_sweetSpotPercentage!.clamp(0, 100).toStringAsFixed(0)} %'
+                        : '尚無資料';
+                final sweetSubtitle = _isMetricCalculating
+                    ? '比對音訊與震動判斷清脆度'
+                    : _sweetSpotPercentage != null
+                        ? '最近錄影的擊球甜蜜點命中率'
+                        : '有 IMU 與麥克風資料後顯示';
+
+                final cards = <Widget>[
+                  _buildStatCard(
+                    title: '練習次數',
+                    value: '$_practiceCount 次',
+                    subTitle: practiceSubtitle,
+                    highlightColor: const Color(0xFF1E8E5A),
+                  ),
+                  _buildStatCard(
+                    title: '平均速度',
+                    value: speedValue,
+                    subTitle: speedSubtitle,
+                    highlightColor: const Color(0xFF2E8EFF),
+                  ),
+                  _buildStatCard(
+                    title: '甜蜜點命中',
+                    value: sweetValue,
+                    subTitle: sweetSubtitle,
+                    highlightColor: const Color(0xFF8E4AF4),
+                  ),
+                ];
+
+                if (constraints.maxWidth > 650) {
+                  return Row(
+                    children: [
+                      for (var i = 0; i < cards.length; i++)
+                        Expanded(
+                          child: Padding(
+                            padding: EdgeInsets.only(right: i == cards.length - 1 ? 0 : 16),
+                            child: cards[i],
+                          ),
+                        ),
+                    ],
+                  );
+                }
+
+                return SingleChildScrollView(
+                  scrollDirection: Axis.horizontal,
+                  child: Row(
+                    children: [
+                      for (var i = 0; i < cards.length; i++)
+                        Padding(
+                          padding: EdgeInsets.only(right: i == cards.length - 1 ? 0 : 12),
+                          child: SizedBox(
+                            width: math.min(240, constraints.maxWidth - 40),
+                            child: cards[i],
+                          ),
+                        ),
+                    ],
+                  ),
+                );
+              },
+            ),
+            const SizedBox(height: 24),
+            _SectionHeader(
+              title: 'Video Library',
+              actionLabel: 'See all',
+              onTap: () => _onBottomNavTap(3),
+            ),
+            const SizedBox(height: 12),
+            if (_isHistoryLoading)
+              SizedBox(
+                height: 190,
+                child: Center(
+                  child: Column(
+                    mainAxisSize: MainAxisSize.min,
+                    children: const [
+                      CircularProgressIndicator(),
+                      SizedBox(height: 12),
+                      Text('正在整理影片庫...', style: TextStyle(fontSize: 14)),
+                    ],
+                  ),
+                ),
+              )
+            else if (displayedHistory.isEmpty)
+              Container(
+                height: 190,
+                alignment: Alignment.center,
+                decoration: BoxDecoration(
+                  color: Colors.white,
+                  borderRadius: BorderRadius.circular(20),
+                  boxShadow: const [
+                    BoxShadow(color: Colors.black12, blurRadius: 8, offset: Offset(0, 4)),
+                  ],
+                ),
+                child: const Text('尚未有錄影影片，完成錄影後會自動收錄最新紀錄。'),
+              )
+            else
+              SizedBox(
+                height: 190,
+                child: ListView.builder(
+                  scrollDirection: Axis.horizontal,
+                  itemCount: displayedHistory.length,
+                  itemBuilder: (context, index) {
+                    final entry = displayedHistory[index];
+                    final color = palette[index % palette.length];
+                    return _buildVideoTile(entry: entry, baseColor: color);
+                  },
+                ),
+              ),
+            const SizedBox(height: 24),
+            Container(
+              padding: const EdgeInsets.all(20),
+              decoration: BoxDecoration(
+                color: Colors.white,
+                borderRadius: BorderRadius.circular(22),
+                boxShadow: const [
+                  BoxShadow(color: Colors.black12, blurRadius: 8, offset: Offset(0, 4)),
+                ],
+              ),
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  _SectionHeader(title: 'Analytics', actionLabel: '詳情報告', onTap: () {}),
+                  const SizedBox(height: 16),
+                  Row(
+                    children: [
+                      Expanded(
+                        child: Column(
+                          crossAxisAlignment: CrossAxisAlignment.start,
+                          children: [
+                            const Text('Avg Speed', style: TextStyle(color: Color(0xFF7D8B9A))),
+                            const SizedBox(height: 6),
+                            Text(
+                              analyticsAvgSpeedText,
+                              style: const TextStyle(
+                                fontSize: 22,
+                                fontWeight: FontWeight.bold,
+                                color: Color(0xFF1E8E5A),
+                              ),
+                            ),
+                            const SizedBox(height: 12),
+                            const Text('Best Speed', style: TextStyle(color: Color(0xFF7D8B9A))),
+                            const SizedBox(height: 6),
+                            Text(
+                              analyticsBestSpeedText,
+                              style: const TextStyle(
+                                fontSize: 20,
+                                fontWeight: FontWeight.bold,
+                                color: Color(0xFF1E8E5A),
+                              ),
+                            ),
+                            const SizedBox(height: 12),
+                            const Text('Stability', style: TextStyle(color: Color(0xFF7D8B9A))),
+                            const SizedBox(height: 6),
+                            Text(
+                              analyticsStabilityText,
+                              style: const TextStyle(
+                                fontSize: 22,
+                                fontWeight: FontWeight.bold,
+                                color: Color(0xFF2E8EFF),
+                              ),
+                            ),
+                            const SizedBox(height: 12),
+                            const Text('Sweet Spot', style: TextStyle(color: Color(0xFF7D8B9A))),
+                            const SizedBox(height: 6),
+                            Text(
+                              analyticsSweetText,
+                              style: const TextStyle(
+                                fontSize: 22,
+                                fontWeight: FontWeight.bold,
+                                color: Color(0xFF8E4AF4),
+                              ),
+                            ),
+                            const SizedBox(height: 12),
+                            const Text('Impact Clarity', style: TextStyle(color: Color(0xFF7D8B9A))),
+                            const SizedBox(height: 6),
+                            Text(
+                              analyticsClarityText,
+                              style: const TextStyle(
+                                fontSize: 20,
+                                fontWeight: FontWeight.bold,
+                                color: Color(0xFFDA4E5D),
+                              ),
+                            ),
+                          ],
+                        ),
+                      ),
+                      SizedBox(
+                        height: 140,
+                        width: 140,
+                        child: CustomPaint(
+                          painter: _RadarChartPainter(values: _buildRadarValues()),
+                        ),
+                      ),
+                    ],
+                  ),
+                ],
+              ),
+            ),
+            const SizedBox(height: 24),
+            _buildComparisonCard(),
+            const SizedBox(height: 32),
+            _buildHistoryShortcutCard(),
+            const SizedBox(height: 32),
+          ],
+        ),
+      ),
+      bottomNavigationBar: _buildBottomBar(),
+    );
+  }
+
+  /// 自訂底部導覽列，模擬設計稿中的五個項目並保留 Quick Start 強調樣式
+  Widget _buildBottomBar() {
+    return Container(
+      padding: const EdgeInsets.symmetric(horizontal: 24, vertical: 10),
+      decoration: const BoxDecoration(
+        color: Colors.white,
+        boxShadow: [BoxShadow(color: Colors.black12, blurRadius: 6, offset: Offset(0, -2))],
+      ),
+      child: Row(
+        mainAxisAlignment: MainAxisAlignment.spaceBetween,
+        children: [
+          _BottomNavItem(
+            icon: Icons.home_rounded,
+            label: 'Home',
+            isActive: _currentIndex == 0,
+            onTap: () => _onBottomNavTap(0),
+          ),
+          _BottomNavItem(
+            icon: Icons.calendar_today_rounded,
+            label: 'Today Info',
+            isActive: _currentIndex == 1,
+            onTap: () => _onBottomNavTap(1),
+          ),
+          _QuickStartNavItem(
+            onTap: () => _onBottomNavTap(2),
+          ),
+          _BottomNavItem(
+            icon: Icons.bar_chart_rounded,
+            label: 'Data Metrics',
+            isActive: _currentIndex == 3,
+            onTap: () => _onBottomNavTap(3),
+          ),
+          _BottomNavItem(
+            icon: Icons.workspace_premium_rounded,
+            label: 'Upgrade',
+            isActive: _currentIndex == 4,
+            onTap: () => _onBottomNavTap(4),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+/// 儀表板指標計算工具：讀取 IMU CSV 並轉換為速度與甜蜜點統計
+class _MetricsCalculator {
+  static const double _impactThreshold = 12.0; // 判定擊球瞬間的加速度門檻
+  static const double _sweetSpotThreshold = 0.18; // 認定為甜蜜點的命中比例
+
+  /// 從歷史紀錄中解析出平均揮桿速度與甜蜜點命中率
+  static Future<_MetricsResult> compute(List<RecordingHistoryEntry> entries) async {
+    double aggregatedSpeed = 0; // 累加每次揮桿的預估速度
+    double aggregatedConsistency = 0; // 累加穩定度比例
+    double aggregatedImpact = 0; // 累加擊球清脆度
+    int speedSamples = 0; // 統計擁有速度資訊的樣本數
+    int sweetSpotHits = 0; // 紀錄甜蜜點命中的次數
+    int analyzedSwings = 0; // 有成功解析的揮桿筆數
+    double? bestSpeedMph; // 歷史最佳速度
+    final entrySnapshots = <_EntrySnapshot>[]; // 紀錄每筆歷史對應的分析結果
+
+    for (final entry in entries) {
+      final csvPath = _selectCsvPath(entry);
+      if (csvPath == null) {
+        entrySnapshots.add(_EntrySnapshot(entry: entry, snapshot: null));
+        continue; // 沒有 IMU 檔案無法推算速度
+      }
+
+      final snapshot = await _analyzeCsv(csvPath);
+      entrySnapshots.add(_EntrySnapshot(entry: entry, snapshot: snapshot));
+      if (snapshot == null) {
+        continue;
+      }
+
+      analyzedSwings++;
+      if (snapshot.estimatedSpeedMph != null) {
+        aggregatedSpeed += snapshot.estimatedSpeedMph!;
+        speedSamples++;
+        bestSpeedMph = bestSpeedMph == null
+            ? snapshot.estimatedSpeedMph
+            : math.max(bestSpeedMph!, snapshot.estimatedSpeedMph!);
+      }
+      aggregatedConsistency += snapshot.consistencyScore;
+      aggregatedImpact += snapshot.impactClarity;
+      if (snapshot.impactClarity >= _sweetSpotThreshold) {
+        sweetSpotHits++;
+      }
+    }
+
+    final averageSpeed = speedSamples > 0 ? aggregatedSpeed / speedSamples : null;
+    final sweetSpotPercentage = analyzedSwings > 0 ? sweetSpotHits / analyzedSwings * 100 : null;
+    final consistencyScore = analyzedSwings > 0
+        ? math.min(math.max(aggregatedConsistency / analyzedSwings, 0.0), 1.0)
+        : null;
+    final averageImpact = analyzedSwings > 0
+        ? math.min(math.max(aggregatedImpact / analyzedSwings, 0.0), 1.0)
+        : null;
+
+    // ---------- 轉換為比較所需資料：取最新與上一筆成功解析的紀錄 ----------
+    final comparable = entrySnapshots
+        .where((item) => item.snapshot != null)
+        .toList()
+      ..sort((a, b) => b.entry.recordedAt.compareTo(a.entry.recordedAt));
+
+    _ComparisonSnapshot? comparisonAfter;
+    _ComparisonSnapshot? comparisonBefore;
+    if (comparable.isNotEmpty) {
+      final latest = comparable.first;
+      comparisonAfter = _ComparisonSnapshot(
+        entry: latest.entry,
+        speedMph: latest.snapshot!.estimatedSpeedMph,
+        impactClarity: latest.snapshot!.impactClarity,
+      );
+      if (comparable.length > 1) {
+        final previous = comparable[1];
+        comparisonBefore = _ComparisonSnapshot(
+          entry: previous.entry,
+          speedMph: previous.snapshot!.estimatedSpeedMph,
+          impactClarity: previous.snapshot!.impactClarity,
+        );
+      }
+    }
+
+    return _MetricsResult(
+      averageSpeedMph: averageSpeed,
+      bestSpeedMph: bestSpeedMph,
+      consistencyScore: consistencyScore,
+      averageImpactClarity: averageImpact,
+      sweetSpotPercentage: sweetSpotPercentage,
+      comparisonBefore: comparisonBefore,
+      comparisonAfter: comparisonAfter,
+    );
+  }
+
+  /// 優先使用手腕裝置，其次胸前裝置，最後取第一個可用 CSV
+  static String? _selectCsvPath(RecordingHistoryEntry entry) {
+    if (entry.imuCsvPaths.isEmpty) {
+      return null;
+    }
+    if (entry.imuCsvPaths['RIGHT_WRIST'] != null && entry.imuCsvPaths['RIGHT_WRIST']!.isNotEmpty) {
+      return entry.imuCsvPaths['RIGHT_WRIST'];
+    }
+    if (entry.imuCsvPaths['CHEST'] != null && entry.imuCsvPaths['CHEST']!.isNotEmpty) {
+      return entry.imuCsvPaths['CHEST'];
+    }
+    final fallback = entry.imuCsvPaths.values.firstWhere(
+      (path) => path.isNotEmpty,
+      orElse: () => '',
+    );
+    return fallback.isNotEmpty ? fallback : null;
+  }
+
+  /// 解析單支 CSV：同時估算平均加速度、峰值與擊球清脆度
+  static Future<_SwingSnapshot?> _analyzeCsv(String path) async {
+    final file = File(path);
+    if (!await file.exists()) {
+      return null;
+    }
+
+    final stream = file.openRead().transform(utf8.decoder).transform(const LineSplitter());
+    double sumMagnitude = 0;
+    double maxMagnitude = 0;
+    int totalSamples = 0;
+    int impactSamples = 0;
+
+    var lineCounter = 0; // 記錄讀取行數，定期讓出主執行緒避免阻塞
+    await for (final rawLine in stream) {
+      final line = rawLine.trim();
+      if (line.isEmpty || line.startsWith('CODI_') || line.startsWith('Device:') || line.startsWith('Quat')) {
+        continue; // 跳過表頭與段落資訊
+      }
+
+      final parts = line.split(',');
+      if (parts.length < 7) {
+        continue; // 欄位不足時不納入計算
+      }
+
+      final ax = double.tryParse(parts[4]) ?? 0;
+      final ay = double.tryParse(parts[5]) ?? 0;
+      final az = double.tryParse(parts[6]) ?? 0;
+      final magnitude = math.sqrt(ax * ax + ay * ay + az * az);
+      if (!magnitude.isFinite) {
+        continue;
+      }
+
+      sumMagnitude += magnitude;
+      if (magnitude > maxMagnitude) {
+        maxMagnitude = magnitude;
+      }
+      if (magnitude >= _impactThreshold) {
+        impactSamples++;
+      }
+      totalSamples++;
+
+      // 每處理一定筆數後暫停一個事件循環，避免大量 CSV 造成 UI 卡住。
+      lineCounter++;
+      if (lineCounter % 400 == 0) {
+        await Future<void>.delayed(Duration.zero);
+      }
+    }
+
+    if (totalSamples == 0) {
+      return null;
+    }
+
+    final avgMagnitude = sumMagnitude / totalSamples;
+    // 透過經驗係數估算揮桿速度：峰值代表爆發力、平均值代表穩定性
+    final estimatedSpeedMps = (avgMagnitude * 0.45) + (maxMagnitude * 0.25);
+    final estimatedSpeedMph = estimatedSpeedMps * 2.23694;
+    final impactClarity = impactSamples / totalSamples;
+    final consistency = maxMagnitude > 0 ? (avgMagnitude / maxMagnitude).clamp(0.0, 1.0) : 0.0;
+
+    return _SwingSnapshot(
+      estimatedSpeedMph: estimatedSpeedMph.isFinite ? estimatedSpeedMph : null,
+      impactClarity: impactClarity.clamp(0.0, 1.0),
+      consistencyScore: consistency,
+    );
+  }
+}
+
+/// 儀表板計算回傳的彙整結果
+class _MetricsResult {
+  final double? averageSpeedMph;
+  final double? bestSpeedMph;
+  final double? consistencyScore;
+  final double? averageImpactClarity;
+  final double? sweetSpotPercentage;
+  final _ComparisonSnapshot? comparisonBefore;
+  final _ComparisonSnapshot? comparisonAfter;
+
+  const _MetricsResult({
+    required this.averageSpeedMph,
+    required this.bestSpeedMph,
+    required this.consistencyScore,
+    required this.averageImpactClarity,
+    required this.sweetSpotPercentage,
+    required this.comparisonBefore,
+    required this.comparisonAfter,
+  });
+}
+
+/// 解析單支 CSV 後的即時統計
+class _SwingSnapshot {
+  final double? estimatedSpeedMph; // 估算出的揮桿速度
+  final double impactClarity; // 高加速度樣本占比，代表擊球清脆度
+  final double consistencyScore; // 平均與峰值的比例，代表穩定度
+
+  const _SwingSnapshot({
+    required this.estimatedSpeedMph,
+    required this.impactClarity,
+    required this.consistencyScore,
+  });
+}
+
+/// 將錄影紀錄與分析結果綁定，供比較與彙整使用
+class _EntrySnapshot {
+  final RecordingHistoryEntry entry; // 原始錄影資訊
+  final _SwingSnapshot? snapshot; // 解析後的感測數據
+
+  const _EntrySnapshot({required this.entry, required this.snapshot});
+}
+
+/// 比較區塊顯示的資料結構
+class _ComparisonSnapshot {
+  final RecordingHistoryEntry entry; // 對應的錄影紀錄
+  final double? speedMph; // 預估揮桿速度
+  final double impactClarity; // 擊球清脆度比例
+
+  const _ComparisonSnapshot({
+    required this.entry,
+    required this.speedMph,
+    required this.impactClarity,
+  });
+}
+
+/// 雷達圖繪製器，呈現五個指標的相對表現
+class _RadarChartPainter extends CustomPainter {
+  final List<double> values; // 介於 0 到 1 的比例值
+
+  const _RadarChartPainter({required this.values});
+
+  @override
+  void paint(Canvas canvas, Size size) {
+    final center = Offset(size.width / 2, size.height / 2);
+    final radius = math.min(size.width, size.height) / 2 * 0.85;
+    final paint = Paint()
+      ..color = const Color(0xFF2E8EFF).withOpacity(0.2)
+      ..style = PaintingStyle.fill;
+
+    final borderPaint = Paint()
+      ..color = const Color(0xFF2E8EFF)
+      ..style = PaintingStyle.stroke
+      ..strokeWidth = 2;
+
+    final path = Path();
+    final angleStep = 2 * math.pi / values.length;
+    for (var i = 0; i < values.length; i++) {
+      final angle = -math.pi / 2 + angleStep * i;
+      final pointRadius = radius * values[i].clamp(0.0, 1.0);
+      final offset = Offset(
+        center.dx + pointRadius * math.cos(angle),
+        center.dy + pointRadius * math.sin(angle),
+      );
+      if (i == 0) {
+        path.moveTo(offset.dx, offset.dy);
+      } else {
+        path.lineTo(offset.dx, offset.dy);
+      }
+    }
+    path.close();
+
+    canvas.drawPath(path, paint);
+    canvas.drawPath(path, borderPaint);
+
+    final gridPaint = Paint()
+      ..color = const Color(0xFFE4E8F0)
+      ..style = PaintingStyle.stroke;
+
+    // 繪製背景網格，提供視覺上的比例參考
+    for (var layer = 1; layer <= 4; layer++) {
+      final layerRadius = radius * layer / 4;
+      final gridPath = Path();
+      for (var i = 0; i < values.length; i++) {
+        final angle = -math.pi / 2 + angleStep * i;
+        final offset = Offset(
+          center.dx + layerRadius * math.cos(angle),
+          center.dy + layerRadius * math.sin(angle),
+        );
+        if (i == 0) {
+          gridPath.moveTo(offset.dx, offset.dy);
+        } else {
+          gridPath.lineTo(offset.dx, offset.dy);
+        }
+      }
+      gridPath.close();
+      canvas.drawPath(gridPath, gridPaint);
+    }
+  }
+
+  @override
+  bool shouldRepaint(covariant _RadarChartPainter oldDelegate) => !listEquals(oldDelegate.values, values);
+}
+
+/// 一般底部導覽按鈕元件
+class _BottomNavItem extends StatelessWidget {
+  final IconData icon;
+  final String label;
+  final bool isActive;
+  final VoidCallback onTap;
+
+  const _BottomNavItem({
+    required this.icon,
+    required this.label,
+    required this.isActive,
+    required this.onTap,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return GestureDetector(
+      onTap: onTap,
+      child: Column(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          Icon(icon, color: isActive ? const Color(0xFF1E8E5A) : const Color(0xFF7D8B9A)),
+          const SizedBox(height: 4),
+          Text(
+            label,
+            style: TextStyle(
+              color: isActive ? const Color(0xFF1E8E5A) : const Color(0xFF7D8B9A),
+              fontWeight: isActive ? FontWeight.bold : FontWeight.normal,
+              fontSize: 12,
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+/// 快速開始按鈕獨立元件，採用圓形浮起樣式凸顯互動焦點
+class _QuickStartNavItem extends StatelessWidget {
+  final VoidCallback onTap;
+
+  const _QuickStartNavItem({required this.onTap});
+
+  @override
+  Widget build(BuildContext context) {
+    return GestureDetector(
+      onTap: onTap,
+      child: Container(
+        width: 70,
+        height: 70,
+        decoration: const BoxDecoration(
+          shape: BoxShape.circle,
+          color: Color(0xFF1E8E5A),
+          boxShadow: [BoxShadow(color: Colors.black26, blurRadius: 10, offset: Offset(0, 6))],
+        ),
+        child: Column(
+          mainAxisAlignment: MainAxisAlignment.center,
+          children: const [
+            Icon(Icons.flash_on_rounded, color: Colors.white),
+            SizedBox(height: 4),
+            Text(
+              'Quick\nStart',
+              textAlign: TextAlign.center,
+              style: TextStyle(color: Colors.white, fontSize: 10, fontWeight: FontWeight.bold),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+/// 區塊標題元件，集中管理標題與右側操作按鈕
+class _SectionHeader extends StatelessWidget {
+  final String title;
+  final String actionLabel;
+  final VoidCallback onTap;
+
+  const _SectionHeader({
+    required this.title,
+    required this.actionLabel,
+    required this.onTap,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Row(
+      children: [
+        Text(
+          title,
+          style: const TextStyle(
+            fontSize: 20,
+            fontWeight: FontWeight.bold,
+            color: Color(0xFF0B2A2E),
+          ),
+        ),
+        const Spacer(),
+        GestureDetector(
+          onTap: onTap,
+          child: Text(
+            actionLabel,
+            style: const TextStyle(color: Color(0xFF1E8E5A), fontWeight: FontWeight.w600),
+          ),
+        ),
+      ],
+    );
+  }
+}

--- a/lib/pages/login_page.dart
+++ b/lib/pages/login_page.dart
@@ -1,0 +1,468 @@
+import 'dart:io'; // 判斷平台以動態決定權限清單
+
+import 'package:camera/camera.dart';
+import 'package:flutter/material.dart';
+import 'package:permission_handler/permission_handler.dart'; // 引入權限處理套件以於登入前檢查授權
+
+import 'home_page.dart';
+
+/// 登入頁面提供使用者輸入帳號密碼後進入首頁
+class LoginPage extends StatefulWidget {
+  final List<CameraDescription> cameras; // 裝置可用鏡頭清單
+
+  const LoginPage({super.key, required this.cameras});
+
+  @override
+  State<LoginPage> createState() => _LoginPageState();
+}
+
+class _LoginPageState extends State<LoginPage> {
+  // ---------- 狀態管理區 ----------
+  final TextEditingController _emailController = TextEditingController(); // 紀錄信箱輸入內容
+  final TextEditingController _passwordController = TextEditingController(); // 紀錄密碼輸入內容
+  final GlobalKey<FormState> _formKey = GlobalKey<FormState>(); // 表單驗證用 key
+  bool _rememberMe = true; // 記住使用者選項
+  bool _isObscure = true; // 控制密碼顯示與否
+  bool _hasRequestedInitialPermissions = false; // 避免重複觸發首次權限請求
+  late final Map<Permission, String> _blePermissions; // 依照平台動態產生的權限顯示名稱
+  Map<Permission, PermissionStatus> _permissionStatuses = {}; // 儲存各項權限授權狀態
+
+  @override
+  void initState() {
+    super.initState();
+    _blePermissions = _buildRequiredPermissions(); // 依平台建立權限清單，避免出現無法授權的項目
+    _permissionStatuses = {
+      for (final permission in _blePermissions.keys)
+        permission: PermissionStatus.denied, // 初始化為未授權，確保提示卡片顯示狀態
+    };
+    // 於元件建立後立即排程權限請求，確保第一次進入登入頁面就彈出系統授權視窗
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      _triggerInitialPermissionRequest();
+    });
+  }
+
+  @override
+  void dispose() {
+    // 組件銷毀時一併釋放控制器，避免記憶體洩漏
+    _emailController.dispose();
+    _passwordController.dispose();
+    super.dispose();
+  }
+
+  // ---------- 方法區 ----------
+  /// 首次進入登入頁面時觸發權限請求，讓使用者立即看到系統彈窗
+  Future<void> _triggerInitialPermissionRequest() async {
+    if (_hasRequestedInitialPermissions) {
+      return; // 已經處理過首次請求就不再重複執行
+    }
+    _hasRequestedInitialPermissions = true;
+
+    await _requestBlePermissions(showDeniedDialog: false); // 首次請求不額外彈說明，僅顯示系統視窗
+
+    // 若仍未全部授權則以 SnackBar 提醒並在畫面上顯示提示卡片
+    if (mounted && !_arePermissionsAllGranted) {
+      ScaffoldMessenger.of(context).showSnackBar(
+        const SnackBar(
+          content: Text('請允許藍牙與定位權限，以確保 IMU 連線功能可用。'),
+          duration: Duration(seconds: 4),
+        ),
+      );
+    }
+  }
+
+  /// 當使用者按下登入按鈕時觸發，先驗證資料再導向首頁
+  Future<void> _handleLogin() async {
+    if (!(_formKey.currentState?.validate() ?? false)) {
+      return; // 若表單驗證失敗則直接結束
+    }
+
+    // 登入前先要求使用者授權藍牙與定位權限，確保後續流程正常運作
+    final permissionsGranted = await _ensureBlePermissions();
+    if (!mounted || !permissionsGranted) {
+      return; // 權限未完整授權時暫停導向首頁
+    }
+
+    // 權限與驗證皆通過後才導向首頁並帶入鏡頭資訊
+    Navigator.of(context).pushReplacement(
+      MaterialPageRoute(
+        builder: (_) => HomePage(
+          userEmail: _emailController.text,
+          cameras: widget.cameras,
+        ),
+      ),
+    );
+  }
+
+  /// 於首次登入時請求藍牙／定位權限，並在拒絕時顯示操作提示
+  Future<bool> _ensureBlePermissions() async {
+    return _requestBlePermissions(showDeniedDialog: true);
+  }
+
+  /// 統一處理藍牙／定位權限請求並更新狀態，可選擇是否於拒絕時顯示說明
+  Future<bool> _requestBlePermissions({required bool showDeniedDialog}) async {
+    final updatedStatuses = <Permission, PermissionStatus>{};
+
+    for (final entry in _blePermissions.entries) {
+      // 使用 request() 以觸發系統授權視窗，並紀錄回傳結果
+      final status = await entry.key.request();
+      updatedStatuses[entry.key] = status;
+    }
+
+    if (!mounted) {
+      return false; // 組件已卸載就不再進行後續流程
+    }
+
+    setState(() {
+      _permissionStatuses = updatedStatuses;
+    });
+
+    if (_arePermissionsAllGranted) {
+      return true; // 全數授權完成即可繼續
+    }
+
+    if (showDeniedDialog) {
+      await _showPermissionGuideDialog();
+    }
+
+    return false;
+  }
+
+  /// 顯示權限說明視窗，指引用戶到正確的位置開啟藍牙／附近裝置／定位權限
+  Future<void> _showPermissionGuideDialog() async {
+    await showDialog<void>(
+      context: context,
+      builder: (dialogContext) {
+        return AlertDialog(
+          title: const Text('需要藍牙與定位權限'),
+          content: const Text(
+            '為了搜尋並連線 IMU 感測裝置，請在系統設定中允許以下權限：\n'
+            '1. 進入「應用程式與通知」或「應用管理」。\n'
+            '2. 選擇 TekSwing 後開啟「權限」。\n'
+            '3. 啟用「附近裝置 / 藍牙」與「定位」權限。\n\n'
+            '若系統未直接顯示藍牙選項，請在權限頁面中尋找「附近裝置」或「位置」並開啟。',
+          ),
+          actions: [
+            TextButton(
+              onPressed: () => Navigator.of(dialogContext).pop(),
+              child: const Text('知道了'),
+            ),
+            TextButton(
+              onPressed: () async {
+                await openAppSettings(); // 開啟系統的應用程式設定頁面
+                if (Navigator.of(dialogContext).canPop()) {
+                  Navigator.of(dialogContext).pop();
+                }
+              },
+              child: const Text('前往設定'),
+            ),
+          ],
+        );
+      },
+    );
+  }
+
+  /// 判斷所有需要的權限是否都已授權
+  bool get _arePermissionsAllGranted {
+    if (_blePermissions.isEmpty) {
+      return true; // 當前平台不需額外權限時直接視為通過
+    }
+
+    if (_permissionStatuses.length < _blePermissions.length) {
+      return false; // 尚未檢查過視為未授權
+    }
+    return _permissionStatuses.values.every(_isStatusEffectivelyGranted);
+  }
+
+  /// 判斷權限狀態是否等同於已授權（含 iOS limited / provisional）
+  bool _isStatusEffectivelyGranted(PermissionStatus? status) {
+    if (status == null) {
+      return false;
+    }
+    if (status.isGranted) {
+      return true;
+    }
+    return status == PermissionStatus.limited || status == PermissionStatus.provisional;
+  }
+
+  /// 依照平台與系統版本決定需要請求的權限項目
+  Map<Permission, String> _buildRequiredPermissions() {
+    // Android 需請求附近裝置（掃描 / 連線）與定位權限；iOS 則需藍牙與定位
+    if (Platform.isAndroid) {
+      return {
+        Permission.bluetoothScan: '藍牙掃描',
+        Permission.bluetoothConnect: '藍牙連線',
+        Permission.locationWhenInUse: '定位',
+      };
+    }
+
+    if (Platform.isIOS) {
+      return {
+        Permission.bluetooth: '藍牙使用',
+        Permission.locationWhenInUse: '定位',
+      };
+    }
+
+    // 其他平台僅保留定位權限，避免出現無法處理的藍牙授權項目
+    return {
+      Permission.locationWhenInUse: '定位',
+    };
+  }
+
+  // ---------- UI 建構區 ----------
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+
+    return Scaffold(
+      body: Container(
+        width: double.infinity,
+        height: double.infinity,
+        decoration: const BoxDecoration(
+          gradient: LinearGradient(
+            colors: [Color(0xFF1E8E5A), Color(0xFF0A3D2E)],
+            begin: Alignment.topCenter,
+            end: Alignment.bottomCenter,
+          ),
+        ),
+        child: SafeArea(
+          child: SingleChildScrollView(
+            padding: const EdgeInsets.symmetric(horizontal: 24, vertical: 32),
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                // 品牌標誌區塊，呼應設計稿上方 TekSwing 標示
+                Row(
+                  children: [
+                    const Icon(Icons.golf_course_rounded, size: 42, color: Colors.white),
+                    const SizedBox(width: 12),
+                    Column(
+                      crossAxisAlignment: CrossAxisAlignment.start,
+                      children: [
+                        Text(
+                          'TekSwing',
+                          style: theme.textTheme.headlineSmall?.copyWith(
+                            color: Colors.white,
+                            fontWeight: FontWeight.bold,
+                          ),
+                        ),
+                        Text(
+                          '智慧揮桿訓練平台',
+                          style: theme.textTheme.titleSmall?.copyWith(color: Colors.white70),
+                        ),
+                      ],
+                    ),
+                  ],
+                ),
+                const SizedBox(height: 36),
+                Text(
+                  '歡迎回來！',
+                  style: theme.textTheme.headlineMedium?.copyWith(
+                    color: Colors.white,
+                    fontWeight: FontWeight.w700,
+                  ),
+                ),
+                const SizedBox(height: 8),
+                Text(
+                  '請登入 TekSwing 以同步揮桿資料並探索最新分析報告。',
+                  style: theme.textTheme.bodyLarge?.copyWith(color: Colors.white70),
+                ),
+                const SizedBox(height: 16),
+                if (!_arePermissionsAllGranted) _buildPermissionReminder(theme),
+                const SizedBox(height: 32),
+                Card(
+                  shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(24)),
+                  elevation: 16,
+                  shadowColor: Colors.black26,
+                  child: Padding(
+                    padding: const EdgeInsets.symmetric(horizontal: 24, vertical: 32),
+                    child: Form(
+                      key: _formKey,
+                      child: Column(
+                        mainAxisSize: MainAxisSize.min,
+                        crossAxisAlignment: CrossAxisAlignment.start,
+                        children: [
+                          Text(
+                            '登入帳號',
+                            style: theme.textTheme.titleLarge?.copyWith(
+                              fontWeight: FontWeight.bold,
+                              color: const Color(0xFF0A3D2E),
+                            ),
+                          ),
+                          const SizedBox(height: 24),
+                          TextFormField(
+                            controller: _emailController,
+                            keyboardType: TextInputType.emailAddress,
+                            decoration: InputDecoration(
+                              labelText: '電子郵件',
+                              hintText: 'you@example.com',
+                              prefixIcon: const Icon(Icons.email_outlined),
+                              border: OutlineInputBorder(
+                                borderRadius: BorderRadius.circular(16),
+                              ),
+                            ),
+                            validator: (value) {
+                              // 確認使用者是否輸入內容與基本格式
+                              if (value == null || value.isEmpty) {
+                                return '請輸入電子郵件';
+                              }
+                              if (!value.contains('@')) {
+                                return '電子郵件格式不正確';
+                              }
+                              return null;
+                            },
+                          ),
+                          const SizedBox(height: 18),
+                          TextFormField(
+                            controller: _passwordController,
+                            obscureText: _isObscure,
+                            decoration: InputDecoration(
+                              labelText: '密碼',
+                              prefixIcon: const Icon(Icons.lock_outline),
+                              suffixIcon: IconButton(
+                                onPressed: () => setState(() => _isObscure = !_isObscure),
+                                icon: Icon(_isObscure ? Icons.visibility : Icons.visibility_off),
+                              ),
+                              border: OutlineInputBorder(
+                                borderRadius: BorderRadius.circular(16),
+                              ),
+                            ),
+                            validator: (value) {
+                              if (value == null || value.isEmpty) {
+                                return '請輸入密碼';
+                              }
+                              if (value.length < 6) {
+                                return '密碼至少需要 6 碼';
+                              }
+                              return null;
+                            },
+                          ),
+                          const SizedBox(height: 12),
+                          Row(
+                            children: [
+                              Checkbox(
+                                value: _rememberMe,
+                                onChanged: (value) => setState(() => _rememberMe = value ?? false),
+                              ),
+                              const Text('記住我'),
+                              const Spacer(),
+                              TextButton(
+                                onPressed: () {},
+                                child: const Text('忘記密碼？'),
+                              ),
+                            ],
+                          ),
+                          const SizedBox(height: 12),
+                          SizedBox(
+                            width: double.infinity,
+                            child: ElevatedButton(
+                              onPressed: () => _handleLogin(), // 透過匿名函式呼叫非同步登入流程
+                              style: ElevatedButton.styleFrom(
+                                padding: const EdgeInsets.symmetric(vertical: 16),
+                                backgroundColor: const Color(0xFF1E8E5A),
+                                shape: RoundedRectangleBorder(
+                                  borderRadius: BorderRadius.circular(18),
+                                ),
+                              ),
+                              child: const Text('登入 TekSwing'),
+                            ),
+                          ),
+                          const SizedBox(height: 12),
+                          SizedBox(
+                            width: double.infinity,
+                            child: OutlinedButton(
+                              onPressed: () {},
+                              style: OutlinedButton.styleFrom(
+                                padding: const EdgeInsets.symmetric(vertical: 16),
+                                side: const BorderSide(color: Color(0xFF1E8E5A)),
+                                shape: RoundedRectangleBorder(
+                                  borderRadius: BorderRadius.circular(18),
+                                ),
+                              ),
+                              child: const Text('以訪客身分瀏覽'),
+                            ),
+                          ),
+                        ],
+                      ),
+                    ),
+                  ),
+                ),
+                const SizedBox(height: 24),
+                Row(
+                  mainAxisAlignment: MainAxisAlignment.center,
+                  children: [
+                    const Icon(Icons.security, color: Colors.white70, size: 18),
+                    const SizedBox(width: 8),
+                    Text(
+                      '所有資料皆採用 256-bit 加密保護',
+                      style: theme.textTheme.bodySmall?.copyWith(color: Colors.white70),
+                    ),
+                  ],
+                ),
+              ],
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+
+  /// 建立權限提示卡片，列出尚未授權的項目與重新請求按鈕
+  Widget _buildPermissionReminder(ThemeData theme) {
+    final chips = _blePermissions.entries.map((entry) {
+      final status = _permissionStatuses[entry.key];
+      final granted = _isStatusEffectivelyGranted(status);
+      return Chip(
+        avatar: Icon(
+          granted ? Icons.check_circle : Icons.error_outline,
+          color: granted ? const Color(0xFF1E8E5A) : Colors.redAccent,
+          size: 20,
+        ),
+        label: Text('${entry.value}${granted ? '：已允許' : '：尚未允許'}'),
+        backgroundColor: granted ? Colors.white : Colors.white.withOpacity(0.85),
+      );
+    }).toList();
+
+    return Card(
+      color: Colors.white.withOpacity(0.9),
+      shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(20)),
+      child: Padding(
+        padding: const EdgeInsets.all(20),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Text(
+              '請先授權藍牙與定位',
+              style: theme.textTheme.titleMedium?.copyWith(
+                color: const Color(0xFF0A3D2E),
+                fontWeight: FontWeight.bold,
+              ),
+            ),
+            const SizedBox(height: 8),
+            Text(
+              '首次登入時需要取得藍牙、附近裝置與定位權限，才能搜尋 IMU 感測器並同步資料。',
+              style: theme.textTheme.bodyMedium?.copyWith(color: const Color(0xFF0A3D2E)),
+            ),
+            const SizedBox(height: 12),
+            Wrap(
+              spacing: 8,
+              runSpacing: 8,
+              children: chips,
+            ),
+            const SizedBox(height: 16),
+            Align(
+              alignment: Alignment.centerRight,
+              child: ElevatedButton.icon(
+                onPressed: () => _requestBlePermissions(showDeniedDialog: true),
+                icon: const Icon(Icons.security),
+                label: const Text('重新檢查權限'),
+                style: ElevatedButton.styleFrom(
+                  backgroundColor: const Color(0xFF1E8E5A),
+                ),
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/pages/recording_history_page.dart
+++ b/lib/pages/recording_history_page.dart
@@ -1,0 +1,557 @@
+import 'dart:async';
+import 'dart:io';
+
+import 'package:file_picker/file_picker.dart';
+import 'package:flutter/foundation.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+
+import '../models/recording_history_entry.dart';
+import '../services/recording_history_storage.dart';
+import 'recording_session_page.dart';
+
+/// 列表操作選項
+enum _HistoryMenuAction { rename, editDuration, delete }
+
+/// 錄影歷史獨立頁面：集中顯示所有曾經錄影的檔案，供使用者重播或挑選外部影片
+class RecordingHistoryPage extends StatefulWidget {
+  final List<RecordingHistoryEntry> entries; // 外部帶入的歷史資料清單
+
+  const RecordingHistoryPage({super.key, required this.entries});
+
+  @override
+  State<RecordingHistoryPage> createState() => _RecordingHistoryPageState();
+}
+
+class _RecordingHistoryPageState extends State<RecordingHistoryPage> {
+  late final List<RecordingHistoryEntry> _entries =
+      List<RecordingHistoryEntry>.from(widget.entries); // 本地複製一份資料避免直接修改來源
+  bool _rebuildScheduled = false; // 避免重複排程 setState 造成框架錯誤
+
+  /// 返回上一頁並帶出更新後的清單
+  void _finishWithResult() {
+    Navigator.of(context).pop(List<RecordingHistoryEntry>.from(_entries));
+  }
+
+  /// 移除指定紀錄並同步刪除實體檔案
+  Future<void> _deleteEntry(RecordingHistoryEntry entry) async {
+    final confirm = await showDialog<bool>(
+      context: context,
+      builder: (dialogContext) {
+        return AlertDialog(
+          title: const Text('刪除影片'),
+          content: Text('確定要刪除「${entry.displayTitle}」嗎？影片與 CSV 將會一併移除。'),
+          actions: [
+            TextButton(
+              onPressed: () => Navigator.of(dialogContext).pop(false),
+              child: const Text('取消'),
+            ),
+            FilledButton(
+              onPressed: () => Navigator.of(dialogContext).pop(true),
+              child: const Text('刪除'),
+            ),
+          ],
+        );
+      },
+    );
+
+    if (confirm != true) {
+      return;
+    }
+
+    final index = _entries.indexWhere((item) =>
+        item.filePath == entry.filePath && item.recordedAt == entry.recordedAt);
+    if (index == -1) {
+      return; // 找不到對應項目時直接結束
+    }
+
+    _entries.removeAt(index); // 先調整資料來源
+    if (mounted) {
+      debugPrint('[歷史頁] 刪除後立即刷新列表，剩餘 ${_entries.length} 筆');
+      setState(() {}); // 通知畫面重新渲染
+    }
+
+    await _removeEntryFiles(entry);
+    await RecordingHistoryStorage.instance.saveHistory(_entries);
+
+    if (!mounted) return;
+    ScaffoldMessenger.of(context).showSnackBar(
+      SnackBar(content: Text('已刪除 ${entry.fileName}')),
+    );
+  }
+
+  /// 顯示輸入框調整秒數並更新記錄
+  Future<void> _editEntryDuration(RecordingHistoryEntry entry) async {
+    debugPrint('[歷史頁] 準備調整影片時長：${entry.fileName} 當前秒數=${entry.durationSeconds}');
+    String tempValue = entry.durationSeconds.toString(); // 暫存輸入內容，避免控制器重複使用
+    final formKey = GlobalKey<FormState>();
+    final newDuration = await showDialog<int>(
+      context: context,
+      builder: (dialogContext) {
+        return AlertDialog(
+          title: const Text('調整影片時長'),
+          content: Form(
+            key: formKey,
+            autovalidateMode: AutovalidateMode.onUserInteraction,
+            child: TextFormField(
+              initialValue: tempValue,
+              keyboardType: TextInputType.number,
+              inputFormatters: [FilteringTextInputFormatter.digitsOnly],
+              decoration: const InputDecoration(
+                labelText: '秒數',
+                helperText: '輸入影片實際秒數（正整數）',
+              ),
+              onChanged: (value) => tempValue = value,
+              validator: (value) {
+                final trimmed = value?.trim() ?? '';
+                final parsed = int.tryParse(trimmed);
+                if (parsed == null || parsed <= 0) {
+                  return '請輸入大於 0 的秒數';
+                }
+                return null;
+              },
+            ),
+          ),
+          actions: [
+            TextButton(
+              onPressed: () => Navigator.of(dialogContext).pop(),
+              child: const Text('取消'),
+            ),
+            FilledButton(
+              onPressed: () {
+                final isValid = formKey.currentState?.validate() ?? false;
+                if (!isValid) {
+                  return;
+                }
+                final parsed = int.parse(tempValue.trim());
+                Navigator.of(dialogContext).pop(parsed);
+              },
+              child: const Text('儲存'),
+            ),
+          ],
+        );
+      },
+    );
+
+    if (!mounted || newDuration == null) {
+      debugPrint('[歷史頁] 調整時長流程取消或頁面已卸載');
+      return;
+    }
+
+    final index = _entries.indexWhere((item) =>
+        item.filePath == entry.filePath && item.recordedAt == entry.recordedAt);
+    if (index == -1) {
+      debugPrint('[歷史頁] 找不到對應紀錄，無法更新時長');
+      return;
+    }
+
+    if (_entries[index].durationSeconds == newDuration) {
+      debugPrint('[歷史頁] 秒數未變更（$newDuration 秒），略過更新');
+      return; // 秒數未變更時略過更新
+    }
+
+    _entries[index] = _entries[index].copyWith(durationSeconds: newDuration);
+    debugPrint('[歷史頁] 更新索引 $index 的時長為 $newDuration 秒，準備儲存');
+    if (mounted) {
+      debugPrint('[歷史頁] 調整秒數後重繪列表');
+      _scheduleRebuild(); // 透過佇列化的排程避免與對話框動畫衝突
+    }
+
+    await RecordingHistoryStorage.instance.saveHistory(_entries);
+
+    if (!mounted) return;
+    ScaffoldMessenger.of(context).showSnackBar(
+      SnackBar(content: Text('已更新 ${entry.displayTitle} 為 $newDuration 秒')),
+    );
+  }
+
+  /// 提供重新命名功能，讓使用者快速辨識影片
+  Future<void> _renameEntry(RecordingHistoryEntry entry) async {
+    final initialText = entry.customName != null && entry.customName!.trim().isNotEmpty
+        ? entry.customName!.trim()
+        : entry.displayTitle;
+    debugPrint('[歷史頁] 準備重新命名影片：${entry.fileName} 初始名稱=$initialText');
+    String tempName = initialText; // 暫存輸入內容，避免控制器釋放後仍被引用
+    final formKey = GlobalKey<FormState>();
+    final newName = await showDialog<String>(
+      context: context,
+      builder: (dialogContext) {
+        return AlertDialog(
+          title: const Text('重新命名影片'),
+          content: Form(
+            key: formKey,
+            autovalidateMode: AutovalidateMode.onUserInteraction,
+            child: TextFormField(
+              initialValue: initialText,
+              maxLength: 40,
+              decoration: const InputDecoration(
+                labelText: '影片名稱',
+                helperText: '可留空以恢復預設名稱',
+              ),
+              onChanged: (value) => tempName = value,
+              validator: (value) {
+                final trimmed = value?.trim() ?? '';
+                if (trimmed.length > 40) {
+                  return '名稱需在 40 字以內';
+                }
+                return null;
+              },
+            ),
+          ),
+          actions: [
+            TextButton(
+              onPressed: () => Navigator.of(dialogContext).pop(),
+              child: const Text('取消'),
+            ),
+            FilledButton(
+              onPressed: () {
+                final isValid = formKey.currentState?.validate() ?? false;
+                if (!isValid) {
+                  return;
+                }
+                Navigator.of(dialogContext).pop(tempName.trim());
+              },
+              child: const Text('儲存'),
+            ),
+          ],
+        );
+      },
+    );
+
+    if (!mounted || newName == null) {
+      debugPrint('[歷史頁] 重新命名流程取消或頁面已卸載');
+      return;
+    }
+
+    final normalizedName = newName.trim();
+    final storedName = normalizedName.isEmpty ? '' : normalizedName;
+    debugPrint('[歷史頁] 重新命名輸入：stored="$storedName"');
+
+    final index = _entries.indexWhere((item) =>
+        item.filePath == entry.filePath && item.recordedAt == entry.recordedAt);
+    if (index == -1) {
+      debugPrint('[歷史頁] 找不到對應紀錄，無法重新命名');
+      return;
+    }
+
+    final originalName = (_entries[index].customName ?? '').trim();
+    if (storedName == originalName) {
+      debugPrint('[歷史頁] 名稱未變更，略過更新');
+      return; // 名稱未變更時不更新檔案
+    }
+
+    final defaultTitle = entry.copyWith(customName: '').displayTitle;
+
+    _entries[index] = _entries[index].copyWith(customName: storedName);
+    debugPrint('[歷史頁] 更新索引 $index 的名稱為 "$storedName"，準備儲存');
+    if (mounted) {
+      debugPrint('[歷史頁] 重新命名後刷新列表');
+      _scheduleRebuild(); // 延後到安全時機再更新畫面
+    }
+
+    await RecordingHistoryStorage.instance.saveHistory(_entries);
+
+    if (!mounted) return;
+    final snackMessage = storedName.isEmpty
+        ? '已恢復影片名稱為 $defaultTitle'
+        : '已將影片命名為 $storedName';
+    ScaffoldMessenger.of(context).showSnackBar(
+      SnackBar(content: Text(snackMessage)),
+    );
+  }
+
+  /// 封裝安全的重繪流程，避免在對話框或排程回呼中直接呼叫 setState
+  void _scheduleRebuild() {
+    if (!mounted) {
+      return; // 若頁面已卸載則不做任何事
+    }
+
+    if (_rebuildScheduled) {
+      debugPrint('[歷史頁] 已有重繪排程，略過此次請求');
+      return;
+    }
+
+    _rebuildScheduled = true;
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      _rebuildScheduled = false;
+      if (!mounted) {
+        debugPrint('[歷史頁] 排程執行時頁面已卸載，取消重繪');
+        return;
+      }
+
+      debugPrint('[歷史頁] 執行排程重繪');
+      setState(() {});
+    });
+  }
+
+  /// 刪除影片檔與對應 CSV
+  Future<void> _removeEntryFiles(RecordingHistoryEntry entry) async {
+    try {
+      final videoFile = File(entry.filePath);
+      if (await videoFile.exists()) {
+        await videoFile.delete();
+      }
+    } catch (_) {
+      // 失敗時忽略，避免打斷流程
+    }
+
+    final thumbnailPath = entry.thumbnailPath;
+    if (thumbnailPath != null && thumbnailPath.isNotEmpty) {
+      try {
+        final thumbFile = File(thumbnailPath);
+        if (await thumbFile.exists()) {
+          await thumbFile.delete();
+        }
+      } catch (_) {
+        // 縮圖刪除失敗無須打斷主流程
+      }
+    }
+
+    for (final path in entry.imuCsvPaths.values) {
+      if (path.isEmpty) continue;
+      try {
+        final csvFile = File(path);
+        if (await csvFile.exists()) {
+          await csvFile.delete();
+        }
+      } catch (_) {
+        // 單筆刪除失敗不影響整體
+      }
+    }
+  }
+
+  // ---------- 方法區 ----------
+  /// 將時間轉換為易讀字串，方便列表展示
+  String _formatTimestamp(DateTime time) {
+    final month = time.month.toString().padLeft(2, '0');
+    final day = time.day.toString().padLeft(2, '0');
+    final hour = time.hour.toString().padLeft(2, '0');
+    final minute = time.minute.toString().padLeft(2, '0');
+    return '${time.year}/$month/$day $hour:$minute';
+  }
+
+  /// 嘗試播放指定的錄影紀錄，並在檔案遺失時提示使用者
+  Future<void> _playEntry(RecordingHistoryEntry entry) async {
+    await _playVideoByPath(entry.filePath, missingFileName: entry.fileName);
+  }
+
+  /// 自外部檔案夾挑選影片後播放，支援檢視非當前清單中的檔案
+  Future<void> _pickExternalVideo() async {
+    final result = await FilePicker.platform.pickFiles(type: FileType.video);
+    if (result == null || result.files.single.path == null) {
+      return;
+    }
+    await _playVideoByPath(result.files.single.path!);
+  }
+
+  /// 實際進行影片播放與檔案檢查的共用方法
+  Future<void> _playVideoByPath(String path, {String? missingFileName}) async {
+    final file = File(path);
+    if (!await file.exists()) {
+      if (!mounted) return;
+      final fallbackName = missingFileName ?? path.split(RegExp(r'[\\/]')).last;
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(content: Text('找不到影片檔案 $fallbackName，請確認檔案是否仍存在於裝置內。')),
+      );
+      return;
+    }
+
+    if (!mounted) return;
+    await Navigator.of(context).push(
+      MaterialPageRoute(builder: (_) => VideoPlayerPage(videoPath: path)),
+    );
+  }
+
+  // ---------- 畫面建構 ----------
+  @override
+  Widget build(BuildContext context) {
+    return WillPopScope(
+      onWillPop: () async {
+        _finishWithResult();
+        return false;
+      },
+      child: Scaffold(
+        appBar: AppBar(
+          title: const Text('錄影歷史'),
+          leading: IconButton(
+            onPressed: _finishWithResult,
+            icon: const Icon(Icons.arrow_back),
+          ),
+          actions: [
+            IconButton(
+              onPressed: _pickExternalVideo,
+              tooltip: '開啟其他影片',
+              icon: const Icon(Icons.folder_open_rounded),
+            ),
+          ],
+        ),
+        body: _entries.isEmpty
+            ? const _EmptyHistoryView()
+            : ListView.separated(
+                padding: const EdgeInsets.symmetric(horizontal: 20, vertical: 16),
+                itemBuilder: (context, index) {
+                  final entry = _entries[index];
+                  return _HistoryTile(
+                    entry: entry,
+                    formattedTime: _formatTimestamp(entry.recordedAt),
+                    onTap: () => _playEntry(entry),
+                    onRename: () => _renameEntry(entry),
+                    onEditDuration: () => _editEntryDuration(entry),
+                    onDelete: () => _deleteEntry(entry),
+                  );
+                },
+                separatorBuilder: (_, __) => const SizedBox(height: 12),
+                itemCount: _entries.length,
+              ),
+      ),
+    );
+  }
+}
+
+/// 空狀態元件：提醒使用者目前沒有歷史資料
+class _EmptyHistoryView extends StatelessWidget {
+  const _EmptyHistoryView();
+
+  @override
+  Widget build(BuildContext context) {
+    return Center(
+      child: Column(
+        mainAxisSize: MainAxisSize.min,
+        children: const [
+          Icon(Icons.video_collection_outlined, size: 72, color: Color(0xFF9AA6B2)),
+          SizedBox(height: 16),
+          Text(
+            '目前沒有錄影紀錄',
+            style: TextStyle(fontSize: 18, fontWeight: FontWeight.w600, color: Color(0xFF123B70)),
+          ),
+          SizedBox(height: 8),
+          Text(
+            '完成一次錄影後即可在此查看歷史影片。',
+            style: TextStyle(fontSize: 13, color: Color(0xFF6F7B86)),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+/// 單筆歷史紀錄的呈現元件，包含標題、時間與檔名資訊
+class _HistoryTile extends StatelessWidget {
+  final RecordingHistoryEntry entry; // 對應的錄影資料
+  final String formattedTime; // 已轉換好的顯示時間
+  final VoidCallback onTap; // 點擊後的播放行為
+  final VoidCallback onRename; // 重新命名影片
+  final VoidCallback onEditDuration; // 調整影片時長
+  final VoidCallback onDelete; // 刪除影片紀錄
+
+  const _HistoryTile({
+    required this.entry,
+    required this.formattedTime,
+    required this.onTap,
+    required this.onRename,
+    required this.onEditDuration,
+    required this.onDelete,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return InkWell(
+      onTap: onTap,
+      borderRadius: BorderRadius.circular(20),
+      child: Container(
+        padding: const EdgeInsets.all(20),
+        decoration: BoxDecoration(
+          color: Colors.white,
+          borderRadius: BorderRadius.circular(20),
+          boxShadow: const [
+            BoxShadow(color: Colors.black12, blurRadius: 10, offset: Offset(0, 4)),
+          ],
+        ),
+        child: Row(
+          children: [
+            Container(
+              padding: const EdgeInsets.all(12),
+              decoration: BoxDecoration(
+                color: const Color(0xFF123B70),
+                borderRadius: BorderRadius.circular(16),
+              ),
+              child: Text(
+                entry.roundIndex.toString(),
+                style: const TextStyle(color: Colors.white, fontWeight: FontWeight.bold, fontSize: 16),
+              ),
+            ),
+            const SizedBox(width: 16),
+            Expanded(
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Text(
+                    entry.displayTitle,
+                    style: const TextStyle(
+                      fontSize: 16,
+                      fontWeight: FontWeight.w600,
+                      color: Color(0xFF123B70),
+                    ),
+                  ),
+                  const SizedBox(height: 6),
+                  Text(
+                    '$formattedTime · ${entry.durationSeconds} 秒 · ${entry.modeLabel}',
+                    style: const TextStyle(fontSize: 13, color: Color(0xFF6F7B86)),
+                  ),
+                  const SizedBox(height: 4),
+                  Text(
+                    entry.fileName,
+                    style: const TextStyle(fontSize: 12, color: Color(0xFF9AA6B2)),
+                  ),
+                  if (entry.hasImuCsv) ...[
+                    const SizedBox(height: 4),
+                    Text(
+                      'IMU CSV：${entry.csvFileNames.join(', ')}',
+                      style: const TextStyle(fontSize: 11, color: Color(0xFF4F5D75)),
+                    ),
+                  ],
+                ],
+              ),
+            ),
+            const Icon(Icons.play_arrow_rounded, color: Color(0xFF1E8E5A), size: 32),
+            const SizedBox(width: 4),
+            PopupMenuButton<_HistoryMenuAction>(
+              tooltip: '更多操作',
+              icon: const Icon(Icons.more_vert, color: Color(0xFF123B70)),
+              onSelected: (action) {
+                // 透過 addPostFrameCallback 於下一幀處理操作，避免 PopupMenu 關閉動畫期間觸發 setState
+                WidgetsBinding.instance.addPostFrameCallback((_) {
+                  switch (action) {
+                    case _HistoryMenuAction.rename:
+                      onRename();
+                      break;
+                    case _HistoryMenuAction.editDuration:
+                      onEditDuration();
+                      break;
+                    case _HistoryMenuAction.delete:
+                      onDelete();
+                      break;
+                  }
+                });
+              },
+              itemBuilder: (context) => const [
+                PopupMenuItem<_HistoryMenuAction>(
+                  value: _HistoryMenuAction.rename,
+                  child: Text('重新命名'),
+                ),
+                PopupMenuItem<_HistoryMenuAction>(
+                  value: _HistoryMenuAction.editDuration,
+                  child: Text('調整時長'),
+                ),
+                PopupMenuItem<_HistoryMenuAction>(
+                  value: _HistoryMenuAction.delete,
+                  child: Text('刪除影片'),
+                ),
+              ],
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/pages/recording_session_page.dart
+++ b/lib/pages/recording_session_page.dart
@@ -1,0 +1,1422 @@
+import 'dart:async';
+import 'dart:io';
+import 'dart:isolate';
+
+import 'package:assets_audio_player/assets_audio_player.dart';
+import 'package:camera/camera.dart';
+import 'package:file_picker/file_picker.dart';
+import 'package:flutter/foundation.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_audio_capture/flutter_audio_capture.dart';
+import 'package:permission_handler/permission_handler.dart';
+import 'package:video_player/video_player.dart';
+import 'package:share_plus/share_plus.dart';
+import 'package:wakelock_plus/wakelock_plus.dart';
+
+import '../models/recording_history_entry.dart';
+import '../widgets/recording_history_sheet.dart';
+import '../services/imu_data_logger.dart';
+
+// ---------- 分享頻道設定 ----------
+const MethodChannel _shareChannel = MethodChannel('share_intent_channel');
+
+// ---------- 分享目標列舉 ----------
+enum _ShareTarget { instagram, facebook, line }
+
+/// 錄影專用頁面：專注鏡頭預覽、倒數與音訊波形，與 IMU 配對頁面分離
+class RecordingSessionPage extends StatefulWidget {
+  final List<CameraDescription> cameras; // 傳入所有可用鏡頭
+  final bool isImuConnected; // 是否已配對 IMU，決定提示訊息
+  final int totalRounds; // 本次預計錄影的輪數
+  final int durationSeconds; // 每輪錄影秒數
+  final bool autoStartOnReady; // 由 IMU 按鈕開啟時自動啟動錄影
+  final Stream<void> imuButtonStream; // 右手腕 IMU 按鈕事件來源
+
+  const RecordingSessionPage({
+    super.key,
+    required this.cameras,
+    required this.isImuConnected,
+    required this.totalRounds,
+    required this.durationSeconds,
+    required this.autoStartOnReady,
+    required this.imuButtonStream,
+  });
+
+  @override
+  State<RecordingSessionPage> createState() => _RecordingSessionPageState();
+}
+
+class _RecordingSessionPageState extends State<RecordingSessionPage> {
+  // ---------- 狀態變數區 ----------
+  CameraController? controller; // 控制鏡頭操作
+  CameraDescription? _activeCamera; // 紀錄當前使用的鏡頭，確保預覽與錄影一致
+  double? _previewAspectRatio; // 記錄初始化時的預覽比例，避免錄影時變動
+  bool isRecording = false; // 標記是否正在錄影
+  List<double> waveform = []; // 即時波形資料
+  List<double> waveformAccumulated = []; // 累積波形資料供繪圖使用
+  final ValueNotifier<int> repaintNotifier = ValueNotifier(0); // 用於觸發波形重繪
+
+  final FlutterAudioCapture _audioCapture = FlutterAudioCapture(); // 音訊擷取工具
+  ReceivePort? _receivePort; // 與 Isolate 溝通的管道
+  Isolate? _isolate; // 處理音訊的背景執行緒，可能尚未建立
+
+  final AssetsAudioPlayer _audioPlayer = AssetsAudioPlayer(); // 播放倒數音效
+  final MethodChannel _volumeChannel = const MethodChannel('volume_button_channel'); // 監聽音量鍵
+  bool _isCountingDown = false; // 避免倒數重複觸發
+  bool _shouldCancelRecording = false; // 控制流程是否應該中斷
+  Completer<void>? _cancelCompleter; // 將取消訊號傳遞給等待中的 Future
+  static const int _restSecondsBetweenRounds = 10; // 每輪錄影間預設的休息秒數
+  final List<RecordingHistoryEntry> _recordedRuns = []; // 累積此次錄影產生的檔案
+  bool _hasTriggeredRecording = false; // 記錄使用者是否啟動過錄影，控制按鈕提示
+  StreamSubscription<void>? _imuButtonSubscription; // 監聽 IMU 按鈕觸發錄影
+  bool _pendingAutoStart = false; // 記錄 IMU 事件是否需等待鏡頭初始化後再啟動
+  final _SessionProgress _sessionProgress = _SessionProgress(); // 集中管理倒數秒數與剩餘輪次
+
+  // ---------- 生命週期 ----------
+  @override
+  void initState() {
+    super.initState();
+    // 進入錄影頁後立即鎖定螢幕常亮，避免長時間錄製時裝置自動休眠
+    unawaited(WakelockPlus.enable());
+    initVolumeKeyListener(); // 建立音量鍵快捷鍵
+    // 鎖定裝置方向為直向，以維持預覽與錄影皆為直式畫面
+    SystemChrome.setPreferredOrientations(const <DeviceOrientation>[
+      DeviceOrientation.portraitUp,
+    ]);
+    _sessionProgress.resetForNewSession(widget.totalRounds); // 初始化狀態列顯示預設剩餘次數
+    _prepareSession(); // 非同步初始化鏡頭，等待使用者手動啟動
+    _pendingAutoStart = widget.autoStartOnReady; // 若由 IMU 開啟則在鏡頭就緒後自動啟動
+    // 監聽 IMU 按鈕事件，隨時可從硬體直接觸發錄影
+    _imuButtonSubscription = widget.imuButtonStream.listen((_) {
+      unawaited(_handleImuButtonTrigger());
+    });
+  }
+
+  @override
+  void dispose() {
+    _triggerCancel(); // 優先發出取消訊號，停止所有倒數與錄影
+    _stopActiveRecording(updateUi: false); // 嘗試停止仍在進行的錄影與音訊擷取
+    controller?.dispose();
+    _volumeChannel.setMethodCallHandler(null); // 解除音量鍵監聽，避免重複綁定
+    _audioPlayer.dispose();
+    _imuButtonSubscription?.cancel(); // 解除 IMU 按鈕監聽，避免資源洩漏
+    _sessionProgress.dispose(); // 停止狀態列的計時器，避免離開頁面後仍持續觸發 setState
+    // 還原應用允許的方向，避免離開錄影頁後仍被鎖定
+    SystemChrome.setPreferredOrientations(DeviceOrientation.values);
+    // 離開頁面時恢復系統預設的螢幕休眠行為
+    unawaited(WakelockPlus.disable());
+    super.dispose();
+  }
+
+  // ---------- 初始化流程 ----------
+  /// 初始化鏡頭與權限，僅建立預覽等待使用者手動啟動錄影
+  Future<void> _prepareSession() async {
+    await Permission.camera.request();
+    await Permission.microphone.request();
+    await Permission.storage.request();
+
+    if (widget.cameras.isEmpty) {
+      if (!mounted) return;
+      ScaffoldMessenger.of(context).showSnackBar(
+        const SnackBar(content: Text('沒有可用鏡頭，無法啟動錄影。')),
+      );
+      return;
+    }
+
+    // 依序測試從最高到較低的解析度，找到裝置可支援的最佳錄影規格
+    // 先挑選最適合錄影的鏡頭，預設選擇後鏡頭，若無則退回清單第一顆
+    _activeCamera = _selectPreferredCamera(widget.cameras);
+
+    final _CameraSelectionResult? selection =
+        await _createBestCameraController(_activeCamera!);
+
+    if (selection == null) {
+      if (!mounted) return;
+      ScaffoldMessenger.of(context).showSnackBar(
+        const SnackBar(content: Text('無法初始化鏡頭，請稍後再試。')),
+      );
+      return;
+    }
+
+    controller = selection.controller;
+    // 針對大多數手機相機，感光元件以橫向為主，因此在直向預覽時需要將寬高互換。
+    // 透過感測器角度判斷是否應交換寬高，再計算適用於直式畫面的長寬比。
+    final bool shouldSwapSide =
+        controller!.description.sensorOrientation % 180 != 0;
+    if (selection.previewSize != null) {
+      _previewAspectRatio = shouldSwapSide
+          ? selection.previewSize!.height / selection.previewSize!.width
+          : selection.previewSize!.width / selection.previewSize!.height;
+    } else {
+      final double rawAspect = controller!.value.aspectRatio;
+      _previewAspectRatio = shouldSwapSide ? (1 / rawAspect) : rawAspect;
+    }
+    // 鎖定鏡頭拍攝方向為直向，確保錄影檔案不會自動旋轉
+    try {
+      await controller!.lockCaptureOrientation(DeviceOrientation.portraitUp);
+    } catch (error, stackTrace) {
+      if (kDebugMode) {
+        debugPrint('lockCaptureOrientation 失敗：$error\n$stackTrace');
+      }
+    }
+    if (kDebugMode) {
+      // 藉由除錯訊息確認實際採用的解析度（部分平台無法回報幀率）
+      debugPrint(
+        'Camera initialized with preset ${selection.preset}, size=${selection.previewSize ?? '未知'}, description=${controller!.description.name}',
+      );
+    }
+    if (!mounted) return;
+    setState(() {}); // 更新畫面顯示預覽
+
+    if (_pendingAutoStart) {
+      // 鏡頭就緒後若先前已有硬體按鈕請求，立即啟動倒數錄影
+      _pendingAutoStart = false;
+      unawaited(_handleImuButtonTrigger());
+    }
+  }
+
+  /// 針對指定鏡頭，嘗試使用最高可支援的解析度與幀率進行初始化
+  Future<_CameraSelectionResult?> _createBestCameraController(
+      CameraDescription description) async {
+    // 解析度優先順序：依照套件提供的列舉，由高至低逐一嘗試
+    const List<ResolutionPreset> presetPriority = <ResolutionPreset>[
+      ResolutionPreset.max,
+      ResolutionPreset.ultraHigh,
+      ResolutionPreset.veryHigh,
+      ResolutionPreset.high,
+      ResolutionPreset.medium,
+      ResolutionPreset.low,
+    ];
+
+    for (final ResolutionPreset preset in presetPriority) {
+      final CameraController testController = CameraController(
+        description,
+        preset,
+        enableAudio: true,
+      );
+
+      try {
+        await testController.initialize();
+
+        // 在初始化後立即準備錄影管線，避免真正開始錄影時觸發重新配置導致鏡頭切換
+        try {
+          await testController.prepareForVideoRecording();
+        } catch (error, stackTrace) {
+          // 部分平台可能尚未實作此 API，失敗時僅輸出除錯資訊不阻斷流程
+          if (kDebugMode) {
+            debugPrint('prepareForVideoRecording 失敗：$error\n$stackTrace');
+          }
+        }
+
+        // 嘗試讀取預覽資訊，若特定平台未提供則以 null 代表未知
+        Size? previewSize;
+        try {
+          previewSize = testController.value.previewSize;
+        } catch (_) {
+          previewSize = null;
+        }
+
+        return _CameraSelectionResult(
+          controller: testController,
+          preset: preset,
+          previewSize: previewSize,
+        );
+      } catch (_) {
+        await testController.dispose();
+      }
+    }
+
+    return null;
+  }
+
+  /// 根據鏡頭清單挑選最適合錄影的鏡頭：優先後鏡頭，其次回退第一顆
+  CameraDescription _selectPreferredCamera(List<CameraDescription> cameras) {
+    // ---------- 邏輯說明 ----------
+    // 1. 大多數揮桿錄影希望使用後鏡頭，因此優先尋找後鏡頭。
+    // 2. 若裝置沒有後鏡頭（例如部分平板），則退回清單中的第一顆以確保功能可用。
+    return cameras.firstWhere(
+      (camera) => camera.lensDirection == CameraLensDirection.back,
+      orElse: () => cameras.first,
+    );
+  }
+
+  /// 建立固定比例的預覽畫面，避免錄影時鏡頭切換解析度導致畫面跳動
+  Widget _buildStablePreview() {
+    if (controller == null || !controller!.value.isInitialized) {
+      return const SizedBox.shrink();
+    }
+
+    final double aspectRatio =
+        _previewAspectRatio ?? controller!.value.aspectRatio;
+
+    return Center(
+      child: AspectRatio(
+        aspectRatio: aspectRatio,
+        child: ClipRect(
+          child: CameraPreview(
+            controller!,
+            child: const SizedBox.shrink(), // 仍可於未來覆寫疊層
+          ),
+        ),
+      ),
+    );
+  }
+
+  /// 建立音量鍵監聽器，讓使用者快速啟動錄影
+  void initVolumeKeyListener() {
+    _volumeChannel.setMethodCallHandler((call) async {
+      if (call.method == 'volume_down') {
+        if (!_isCountingDown && !isRecording && controller != null && controller!.value.isInitialized) {
+          _isCountingDown = true;
+          try {
+            await playCountdownAndStart();
+          } finally {
+            _isCountingDown = false;
+          }
+        }
+      }
+    });
+  }
+
+  /// 由 IMU 按鈕觸發錄影，統一檢查鏡頭與倒數狀態
+  Future<void> _handleImuButtonTrigger() async {
+    if (!mounted) {
+      return;
+    }
+    if (controller == null || !controller!.value.isInitialized) {
+      // 鏡頭尚未準備完成，保留旗標待完成初始化後再自動啟動
+      _pendingAutoStart = true;
+      return;
+    }
+    if (_isCountingDown || isRecording) {
+      return; // 已在倒數或錄影中則忽略額外事件
+    }
+
+    _isCountingDown = true; // 鎖定狀態避免連續觸發
+    try {
+      await playCountdownAndStart();
+    } finally {
+      _isCountingDown = false;
+    }
+  }
+
+  /// 發送取消錄影訊號，讓倒數與錄影流程可以即時中斷
+  void _triggerCancel() {
+    _shouldCancelRecording = true;
+    if (_cancelCompleter != null && !_cancelCompleter!.isCompleted) {
+      _cancelCompleter!.complete();
+    }
+    _sessionProgress.resetToIdle(setStateCallback: mounted ? setState : null); // 取消時立即重置倒數資訊
+  }
+
+  /// 主動停止鏡頭錄影與音訊擷取，確保返回上一頁後不再持續錄製
+  Future<void> _stopActiveRecording({bool updateUi = true}) async {
+    if (!isRecording && !_isCountingDown && controller != null && !(controller!.value.isRecordingVideo)) {
+      return; // 若沒有任何錄影流程在進行，可直接返回
+    }
+
+    try {
+      await _audioPlayer.stop();
+    } catch (_) {
+      // 音檔可能尚未播放完成，忽略停止時的錯誤
+    }
+
+    if (controller != null && controller!.value.isRecordingVideo) {
+      try {
+        await controller!.stopVideoRecording();
+      } catch (_) {
+        // 若已停止或尚未開始錄影，忽略錯誤
+      }
+    }
+
+    await _closeAudioPipeline();
+
+    if (ImuDataLogger.instance.hasActiveRound) {
+      await ImuDataLogger.instance.abortActiveRound();
+    }
+
+    if (mounted && updateUi) {
+      setState(() => isRecording = false);
+    } else {
+      isRecording = false;
+    }
+  }
+
+  /// 停止音訊擷取並回收相關資源，確保下次錄影前狀態乾淨
+  Future<void> _closeAudioPipeline() async {
+    try {
+      await _audioCapture.stop();
+    } catch (_) {
+      // 可能尚未成功啟動音訊擷取，忽略錯誤避免阻斷流程
+    }
+    _receivePort?.close();
+    _receivePort = null;
+    _isolate?.kill(priority: Isolate.immediate);
+    _isolate = null;
+  }
+
+  /// 初始化音訊擷取並將資料傳入獨立 Isolate
+  Future<void> initAudioCapture() async {
+    try {
+      _receivePort = ReceivePort();
+      _receivePort!.listen((data) {
+        if (data is List<double>) {
+          waveform = data;
+          waveformAccumulated.addAll(data);
+
+          repaintNotifier.value++; // 通知波形重繪
+        }
+      });
+      _isolate = await Isolate.spawn(
+        _audioProcessingIsolate,
+        _receivePort!.sendPort,
+      );
+      await _audioCapture.init();
+      await _audioCapture.start(
+        (data) => _receivePort?.sendPort.send(
+          List<double>.from((data as List).map((e) => e as double)),
+        ),
+        onError,
+        sampleRate: 22050,
+        bufferSize: 512,
+      );
+    } catch (e) {
+      debugPrint('🎙️ 初始化失敗: $e');
+      rethrow;
+    }
+  }
+
+  // ---------- 方法區 ----------
+  /// 依秒數逐步等待，遇到取消訊號時即刻跳出
+  Future<void> _waitForDuration(int seconds) async {
+    for (int i = 0; i < seconds && !_shouldCancelRecording; i++) {
+      await Future.delayed(const Duration(seconds: 1));
+      if (_shouldCancelRecording) {
+        break;
+      }
+    }
+  }
+
+  /// 播放倒數音效並等待音檔結束或取消
+  Future<void> _playCountdown() async {
+    const int countdownSeconds = 3; // 倒數音效長度（秒）
+    const int bufferSeconds = 3; // 倒數後的緩衝時間
+    final int totalSeconds = countdownSeconds + bufferSeconds;
+
+    _sessionProgress.startCountdown(
+      seconds: totalSeconds,
+      setStateCallback: mounted ? setState : null,
+    );
+
+    await _audioPlayer.open(
+      Audio('assets/sounds/1.mp3'),
+      autoStart: true,
+      showNotification: false,
+    );
+
+    final Future<void> countdownFuture = _waitForDuration(totalSeconds);
+    final Future<void> audioFuture = _audioPlayer.playlistFinished.first;
+
+    await Future.any([
+      Future.wait([countdownFuture, audioFuture]),
+      if (_cancelCompleter != null) _cancelCompleter!.future,
+    ]);
+
+    _sessionProgress.finishCountdown(setStateCallback: mounted ? setState : null);
+  }
+
+  /// 進行一次錄影流程（倒數 -> 錄影 -> 儲存）
+  Future<bool> _recordOnce(int index) async {
+    if (_shouldCancelRecording) {
+      return false; // 若已收到取消訊號則直接跳出，避免繼續操作鏡頭
+    }
+
+    bool recordedSuccessfully = false; // 標記本輪是否完整完成，供外層計算剩餘次數
+    try {
+      waveformAccumulated.clear();
+      await initAudioCapture();
+      if (_shouldCancelRecording) {
+        await _closeAudioPipeline();
+        if (ImuDataLogger.instance.hasActiveRound) {
+          await ImuDataLogger.instance.abortActiveRound();
+        }
+        return false;
+      }
+
+      final baseName = ImuDataLogger.instance.buildBaseFileName(
+        roundIndex: index + 1,
+      );
+      await ImuDataLogger.instance.startRoundLogging(baseName);
+
+      await controller!.startVideoRecording();
+
+      _sessionProgress.startRecording(
+        seconds: widget.durationSeconds,
+        setStateCallback: mounted ? setState : null,
+      );
+
+      await _waitForDuration(widget.durationSeconds);
+
+      if (_shouldCancelRecording) {
+        if (controller!.value.isRecordingVideo) {
+          try {
+            await controller!.stopVideoRecording();
+          } catch (_) {}
+        }
+        await _closeAudioPipeline();
+        if (ImuDataLogger.instance.hasActiveRound) {
+          await ImuDataLogger.instance.abortActiveRound();
+        }
+        return false;
+      }
+
+      final XFile videoFile = await controller!.stopVideoRecording();
+      await _closeAudioPipeline();
+
+      final savedVideoPath = await ImuDataLogger.instance.persistVideoFile(
+        sourcePath: videoFile.path,
+        baseName: baseName,
+      );
+
+      String? savedThumbnailPath;
+      try {
+        // ---------- 拍攝縮圖 ----------
+        // 使用 takePicture 直接捕捉預覽畫面，避免再次開啟 MediaMetadataRetriever。
+        final stillImage = await controller!.takePicture();
+        savedThumbnailPath = await ImuDataLogger.instance
+            .persistThumbnailFromPicture(
+          sourcePath: stillImage.path,
+          baseName: baseName,
+        );
+      } catch (error) {
+        debugPrint('⚠️ 錄影後拍攝縮圖失敗：$error');
+      }
+      final csvPaths = ImuDataLogger.instance.hasActiveRound
+          ? await ImuDataLogger.instance.finishRoundLogging()
+          : <String, String>{};
+
+      final entry = RecordingHistoryEntry(
+        filePath: savedVideoPath,
+        roundIndex: index + 1,
+        recordedAt: DateTime.now(),
+        durationSeconds: widget.durationSeconds,
+        imuConnected: widget.isImuConnected,
+        imuCsvPaths: csvPaths,
+        thumbnailPath: savedThumbnailPath,
+      );
+
+      if (mounted) {
+        setState(() {
+          // 新紀錄置頂顯示，方便使用者快速找到最新檔案
+          _recordedRuns.insert(0, entry);
+        });
+      } else {
+        _recordedRuns.insert(0, entry);
+      }
+
+      debugPrint('✅ 儲存影片與感測資料：${entry.fileName}');
+      recordedSuccessfully = true;
+    } catch (e) {
+      await ImuDataLogger.instance.abortActiveRound();
+      debugPrint('❌ 錄影時出錯：$e');
+    }
+
+    return recordedSuccessfully;
+  }
+
+  /// 依使用者設定自動執行多輪倒數與錄影，中間保留休息時間
+  Future<void> playCountdownAndStart() async {
+    if (controller == null || !controller!.value.isInitialized) {
+      return; // 鏡頭尚未準備完成時不執行
+    }
+
+    if (isRecording) {
+      return; // 避免重複點擊時重入流程
+    }
+
+    if (!widget.isImuConnected && mounted) {
+      // 若尚未連線 IMU，仍允許錄影但提示使用者僅能取得畫面
+      ScaffoldMessenger.of(context).showSnackBar(
+        const SnackBar(content: Text('尚未連線 IMU，將以純錄影模式進行。')),
+      );
+    }
+
+    if (mounted) {
+      setState(() {
+        isRecording = true;
+        _hasTriggeredRecording = true; // 使用者已主動啟動錄影
+        _sessionProgress.resetForNewSession(widget.totalRounds); // 新一輪錄影重新計算剩餘次數
+      });
+    } else {
+      isRecording = true;
+      _hasTriggeredRecording = true;
+      _sessionProgress.resetForNewSession(widget.totalRounds);
+    }
+
+    _shouldCancelRecording = false;
+    _cancelCompleter = Completer<void>();
+
+    try {
+      for (int i = 0; i < widget.totalRounds; i++) {
+        if (_shouldCancelRecording) break;
+
+        _sessionProgress.markCurrentRound(i + 1, setStateCallback: mounted ? setState : null);
+        await _playCountdown();
+        if (_shouldCancelRecording) break;
+
+        final bool recorded = await _recordOnce(i);
+        if (recorded) {
+          _sessionProgress.completeCurrentRound(setStateCallback: mounted ? setState : null);
+        }
+        if (_shouldCancelRecording) break;
+
+        if (recorded && i < widget.totalRounds - 1) {
+          _sessionProgress.startRest(
+            seconds: _restSecondsBetweenRounds,
+            setStateCallback: mounted ? setState : null,
+          );
+          await _waitForDuration(_restSecondsBetweenRounds);
+        }
+      }
+    } finally {
+      _cancelCompleter = null;
+      _shouldCancelRecording = false;
+      _sessionProgress.resetToIdle(setStateCallback: mounted ? setState : null);
+      if (mounted) {
+        setState(() => isRecording = false);
+      } else {
+        isRecording = false;
+      }
+    }
+  }
+
+  /// 讓使用者自選影片並播放
+  Future<void> _pickAndPlayVideo() async {
+    final result = await FilePicker.platform.pickFiles(
+      type: FileType.video,
+      initialDirectory: '/storage/emulated/0/Download',
+    );
+
+    if (!mounted) return;
+
+    if (result != null && result.files.single.path != null) {
+      final filePath = result.files.single.path!;
+      _openVideoPlayer(filePath);
+    }
+  }
+
+  /// 直接開啟影片播放頁面，統一處理導覽流程
+  Future<void> _openVideoPlayer(String filePath) async {
+    if (!mounted) return;
+    await Navigator.push(
+      context,
+      MaterialPageRoute(builder: (_) => VideoPlayerPage(videoPath: filePath)),
+    );
+  }
+
+  /// 彈出歷史列表，提供使用者快速檢視本次錄影成果
+  Future<void> _showRecordedRunsSheet() {
+    return showRecordingHistorySheet(
+      context: context,
+      entries: _recordedRuns,
+      onPlayEntry: (entry) => _openVideoPlayer(entry.filePath),
+      onPickExternal: _pickAndPlayVideo,
+    );
+  }
+
+  /// 音訊處理的 Isolate 主體（保留為預留擴充）
+  static void _audioProcessingIsolate(SendPort sendPort) {}
+
+  /// 音訊擷取錯誤處理
+  void onError(Object e) {
+    debugPrint('❌ Audio Capture Error: $e');
+  }
+
+  /// 處理返回上一頁事件：先停止錄影再允許跳轉
+  Future<bool> _handleWillPop() async {
+    _triggerCancel();
+    await _stopActiveRecording();
+
+    if (mounted) {
+      Navigator.of(context).pop(List<RecordingHistoryEntry>.from(_recordedRuns));
+    }
+    return false;
+  }
+
+  // ---------- 畫面建構 ----------
+  @override
+  Widget build(BuildContext context) {
+    if (controller == null || !controller!.value.isInitialized) {
+      return const Scaffold(body: Center(child: CircularProgressIndicator()));
+    }
+
+    return WillPopScope(
+      onWillPop: _handleWillPop,
+      child: Scaffold(
+        appBar: AppBar(
+          title: const Text('錄影進行中'),
+          backgroundColor: const Color(0xFF123B70),
+        ),
+        body: Column(
+          crossAxisAlignment: CrossAxisAlignment.stretch,
+          children: [
+            if (!widget.isImuConnected)
+              Container(
+                width: double.infinity,
+                padding: const EdgeInsets.symmetric(horizontal: 20, vertical: 14),
+                color: const Color(0xFFFFF4E5),
+                child: const Text(
+                  '目前為純錄影模式，返回上一頁可再次嘗試配對 IMU。',
+                  style: TextStyle(color: Color(0xFF9A6A2F), fontSize: 13),
+                ),
+              ),
+            Container(
+              padding: const EdgeInsets.symmetric(horizontal: 20, vertical: 12),
+              color: const Color(0xFFF4F7FB),
+              child: Text(
+                '本次預計錄影 ${widget.totalRounds} 次，每次 ${widget.durationSeconds} 秒。',
+                style: const TextStyle(fontSize: 14, color: Color(0xFF123B70), fontWeight: FontWeight.w600),
+              ),
+            ),
+            if (!_hasTriggeredRecording)
+              Container(
+                width: double.infinity,
+                padding: const EdgeInsets.symmetric(horizontal: 20, vertical: 10),
+                color: const Color(0xFFE8F5E9),
+                child: const Text(
+                  '請確認站位後，點選右下角「開始錄影」才會啟動倒數。',
+                  style: TextStyle(color: Color(0xFF1E8E5A), fontSize: 13),
+                ),
+              ),
+            _SessionStatusBar(
+              totalRounds: widget.totalRounds,
+              remainingRounds: _sessionProgress.calculateRemainingRounds(),
+              activePhase: _sessionProgress.activePhase,
+              secondsLeft: _sessionProgress.secondsLeft,
+            ),
+            Expanded(
+              child: Stack(
+                children: [
+                  Column(
+                    children: [
+                      Expanded(
+                        child: Stack(
+                          children: [
+                            _buildStablePreview(),
+                            const Positioned.fill(
+                              child: StanceGuideOverlay(),
+                            ),
+                          ],
+                        ),
+                      ),
+                      SizedBox(
+                        height: 200,
+                        width: double.infinity,
+                        child: WaveformWidget(
+                          waveformAccumulated: List.from(waveformAccumulated),
+                          repaintNotifier: repaintNotifier,
+                        ),
+                      ),
+                    ],
+                  ),
+                  Positioned(
+                    bottom: 20,
+                    right: 20,
+                    child: ElevatedButton(
+                      onPressed: isRecording ? null : playCountdownAndStart,
+                      style: ElevatedButton.styleFrom(
+                        backgroundColor: const Color(0xFF1E8E5A),
+                        padding: const EdgeInsets.symmetric(horizontal: 20, vertical: 16),
+                        shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(18)),
+                      ),
+                      child: Text(
+                        isRecording
+                            ? '錄製中...'
+                            : (_hasTriggeredRecording ? '再次錄製' : '開始錄影'),
+                        style: const TextStyle(fontSize: 15, fontWeight: FontWeight.bold),
+                      ),
+                    ),
+                  ),
+                  Positioned(
+                    bottom: 20,
+                    left: 20,
+                    child: ElevatedButton(
+                      onPressed: _showRecordedRunsSheet,
+                      style: ElevatedButton.styleFrom(
+                        backgroundColor: const Color(0xFF123B70),
+                        padding: const EdgeInsets.symmetric(horizontal: 20, vertical: 16),
+                        shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(18)),
+                      ),
+                      child: const Text(
+                        '曾經錄影紀錄',
+                        style: TextStyle(fontSize: 15, fontWeight: FontWeight.bold),
+                      ),
+                    ),
+                  ),
+                ],
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+/// 錄影流程的各種階段，以便統一更新狀態列與倒數資訊
+enum _SessionPhase { idle, countdown, recording, rest }
+
+/// 專責管理倒數秒數、剩餘輪次與計時器的協助類別
+class _SessionProgress {
+  int _totalRounds = 0; // 本次預計錄影的總輪數
+  int _completedRounds = 0; // 已成功完成的輪數
+  int _currentRound = 0; // 目前正在處理的輪數（含倒數或錄影中）
+
+  _SessionPhase activePhase = _SessionPhase.idle; // 當前階段
+  int secondsLeft = 0; // 當前階段剩餘秒數
+
+  Timer? _timer; // 控制倒數的計時器
+
+  /// 初始化新的錄影任務，重置剩餘輪數與倒數資訊
+  void resetForNewSession(int totalRounds) {
+    _cancelTimer();
+    _totalRounds = totalRounds;
+    _completedRounds = 0;
+    _currentRound = 0;
+    activePhase = _SessionPhase.idle;
+    secondsLeft = 0;
+  }
+
+  /// 紀錄目前準備進行的輪次，讓剩餘次數即刻反映
+  void markCurrentRound(int roundIndex, {void Function(VoidCallback fn)? setStateCallback}) {
+    void update(VoidCallback fn) {
+      if (setStateCallback != null) {
+        setStateCallback!(fn);
+      } else {
+        fn();
+      }
+    }
+
+    update(() {
+      _currentRound = roundIndex;
+      if (activePhase == _SessionPhase.idle) {
+        activePhase = _SessionPhase.countdown;
+        secondsLeft = 0;
+      }
+    });
+  }
+
+  /// 啟動倒數計時（含倒數音效與緩衝時間）
+  void startCountdown({required int seconds, void Function(VoidCallback fn)? setStateCallback}) {
+    _startPhaseTimer(
+      phase: _SessionPhase.countdown,
+      seconds: seconds,
+      setStateCallback: setStateCallback,
+    );
+  }
+
+  /// 完成倒數後重置資訊，避免停留在倒數狀態
+  void finishCountdown({void Function(VoidCallback fn)? setStateCallback}) {
+    if (activePhase != _SessionPhase.countdown) {
+      return;
+    }
+    _cancelTimer();
+
+    void update(VoidCallback fn) {
+      if (setStateCallback != null) {
+        setStateCallback!(fn);
+      } else {
+        fn();
+      }
+    }
+
+    update(() {
+      secondsLeft = 0;
+      activePhase = _SessionPhase.idle;
+    });
+  }
+
+  /// 開始正式錄影時計算剩餘秒數
+  void startRecording({required int seconds, void Function(VoidCallback fn)? setStateCallback}) {
+    _startPhaseTimer(
+      phase: _SessionPhase.recording,
+      seconds: seconds,
+      setStateCallback: setStateCallback,
+    );
+  }
+
+  /// 輪次完成後更新已完成數量
+  void completeCurrentRound({void Function(VoidCallback fn)? setStateCallback}) {
+    void update(VoidCallback fn) {
+      if (setStateCallback != null) {
+        setStateCallback!(fn);
+      } else {
+        fn();
+      }
+    }
+
+    update(() {
+      if (_currentRound > _completedRounds) {
+        _completedRounds = _currentRound;
+      }
+      activePhase = _SessionPhase.idle;
+      secondsLeft = 0;
+    });
+  }
+
+  /// 啟動兩輪錄影間的休息倒數
+  void startRest({required int seconds, void Function(VoidCallback fn)? setStateCallback}) {
+    _startPhaseTimer(
+      phase: _SessionPhase.rest,
+      seconds: seconds,
+      setStateCallback: setStateCallback,
+    );
+  }
+
+  /// 手動重置狀態列，常用於取消錄影或流程結束
+  void resetToIdle({void Function(VoidCallback fn)? setStateCallback}) {
+    _cancelTimer();
+
+    void update(VoidCallback fn) {
+      if (setStateCallback != null) {
+        setStateCallback!(fn);
+      } else {
+        fn();
+      }
+    }
+
+    update(() {
+      activePhase = _SessionPhase.idle;
+      secondsLeft = 0;
+      _currentRound = 0;
+    });
+  }
+
+  /// 釋放計時器資源，避免離開頁面後仍持續觸發
+  void dispose() {
+    _cancelTimer();
+  }
+
+  /// 計算剩餘尚未完成的錄影次數
+  int calculateRemainingRounds() {
+    final bool roundInProgress =
+        activePhase == _SessionPhase.countdown || activePhase == _SessionPhase.recording;
+    final int consumed = _completedRounds + (roundInProgress ? 1 : 0);
+    final int remaining = _totalRounds - consumed;
+    return remaining < 0 ? 0 : remaining;
+  }
+
+  void _startPhaseTimer({
+    required _SessionPhase phase,
+    required int seconds,
+    void Function(VoidCallback fn)? setStateCallback,
+  }) {
+    _cancelTimer();
+
+    void update(VoidCallback fn) {
+      if (setStateCallback != null) {
+        setStateCallback!(fn);
+      } else {
+        fn();
+      }
+    }
+
+    update(() {
+      activePhase = phase;
+      secondsLeft = seconds;
+    });
+
+    if (seconds <= 0) {
+      if (phase != _SessionPhase.recording) {
+        update(() {
+          activePhase = _SessionPhase.idle;
+        });
+      }
+      return;
+    }
+
+    _timer = Timer.periodic(const Duration(seconds: 1), (timer) {
+      final int remaining = seconds - timer.tick;
+      update(() {
+        secondsLeft = remaining > 0 ? remaining : 0;
+        if (secondsLeft == 0 && phase != _SessionPhase.recording) {
+          activePhase = _SessionPhase.idle;
+        }
+      });
+
+      if (remaining <= 0) {
+        timer.cancel();
+        _timer = null;
+      }
+    });
+  }
+
+  void _cancelTimer() {
+    _timer?.cancel();
+    _timer = null;
+  }
+}
+
+/// 錄影狀態列：呈現剩餘次數、倒數秒數與休息時間
+class _SessionStatusBar extends StatelessWidget {
+  final int totalRounds;
+  final int remainingRounds;
+  final _SessionPhase activePhase;
+  final int secondsLeft;
+
+  const _SessionStatusBar({
+    required this.totalRounds,
+    required this.remainingRounds,
+    required this.activePhase,
+    required this.secondsLeft,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final TextStyle labelStyle = TextStyle(
+      color: const Color(0xFF123B70).withOpacity(0.7),
+      fontSize: 12,
+      fontWeight: FontWeight.w500,
+    );
+
+    final bool showingCountdown =
+        activePhase == _SessionPhase.countdown || activePhase == _SessionPhase.recording;
+    final bool showingRest = activePhase == _SessionPhase.rest;
+
+    final String countdownText = showingCountdown ? '${secondsLeft.toString()} 秒' : '--';
+    final String restText = showingRest ? '${secondsLeft.toString()} 秒' : '--';
+
+    return Container(
+      padding: const EdgeInsets.symmetric(horizontal: 20, vertical: 12),
+      color: const Color(0xFFE1EBF7),
+      child: Row(
+        children: [
+          _SessionStatusTile(
+            label: '剩餘錄影',
+            value: '$remainingRounds / $totalRounds 次',
+            labelStyle: labelStyle,
+          ),
+          const SizedBox(width: 12),
+          _SessionStatusTile(
+            label: '倒數時間',
+            value: countdownText,
+            labelStyle: labelStyle,
+          ),
+          const SizedBox(width: 12),
+          _SessionStatusTile(
+            label: '休息時間',
+            value: restText,
+            labelStyle: labelStyle,
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+/// 狀態列的小卡片樣式，保持排版一致
+class _SessionStatusTile extends StatelessWidget {
+  final String label;
+  final String value;
+  final TextStyle labelStyle;
+
+  const _SessionStatusTile({
+    required this.label,
+    required this.value,
+    required this.labelStyle,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Expanded(
+      child: Container(
+        padding: const EdgeInsets.symmetric(vertical: 8, horizontal: 12),
+        decoration: BoxDecoration(
+          color: Colors.white,
+          borderRadius: BorderRadius.circular(12),
+          boxShadow: [
+            BoxShadow(
+              color: Colors.black.withOpacity(0.05),
+              blurRadius: 8,
+              offset: const Offset(0, 4),
+            ),
+          ],
+        ),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            Text(label, style: labelStyle),
+            const SizedBox(height: 8),
+            Text(
+              value,
+              style: const TextStyle(
+                fontSize: 16,
+                fontWeight: FontWeight.w700,
+                color: Color(0xFF123B70),
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+/// 封裝鏡頭初始化後的結果，保留可用的解析度資訊
+class _CameraSelectionResult {
+  const _CameraSelectionResult({
+    required this.controller,
+    required this.preset,
+    required this.previewSize,
+  });
+
+  final CameraController controller; // 已初始化可直接使用的鏡頭控制器
+  final ResolutionPreset preset; // 成功套用的解析度列舉值
+  final Size? previewSize; // 實際解析度尺寸，無法取得時為 null
+}
+
+/// 用於顯示波形的 Widget，接收累積資料並觸發重繪
+class WaveformWidget extends StatelessWidget {
+  final List<double> waveformAccumulated; // 波形資料來源
+  final ValueNotifier<int> repaintNotifier; // 外部通知刷新
+
+  const WaveformWidget({
+    super.key,
+    required this.waveformAccumulated,
+    required this.repaintNotifier,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return ValueListenableBuilder<int>(
+      valueListenable: repaintNotifier,
+      builder: (context, value, child) {
+        return CustomPaint(
+          size: Size.infinite,
+          painter: WaveformPainter(List.from(waveformAccumulated)),
+        );
+      },
+    );
+  }
+}
+
+/// 自訂波形畫家，將音訊振幅轉成畫面線條
+class WaveformPainter extends CustomPainter {
+  final List<double> waveform;
+  WaveformPainter(this.waveform);
+
+  @override
+  void paint(Canvas canvas, Size size) {
+    final paint = Paint()
+      ..color = Colors.blue
+      ..strokeWidth = 1.0;
+
+    if (waveform.isEmpty) return;
+
+    final double middle = size.height / 2;
+    final int maxSamples = size.width.toInt();
+    final int skip = waveform.length ~/ maxSamples;
+    if (skip == 0) return;
+
+    for (int i = 0; i < maxSamples; i++) {
+      final int idx = i * skip;
+      if (idx >= waveform.length) break;
+      final double x = i.toDouble();
+      final double y = middle - waveform[idx] * 500;
+      canvas.drawLine(Offset(x, middle), Offset(x, y), paint);
+    }
+  }
+
+  @override
+  bool shouldRepaint(covariant CustomPainter oldDelegate) => true;
+}
+
+/// 揮桿站位指引覆蓋層，協助使用者對齊姿勢
+class StanceGuideOverlay extends StatelessWidget {
+  const StanceGuideOverlay({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return IgnorePointer(
+      child: CustomPaint(
+        painter: _StanceGuidePainter(),
+      ),
+    );
+  }
+}
+
+/// 自訂畫家：繪製左右對稱的揮桿人形與置中的箭頭提示
+class _StanceGuidePainter extends CustomPainter {
+  @override
+  void paint(Canvas canvas, Size size) {
+    // ---------- 畫面設定 ----------
+    final Paint guidelinePaint = Paint()
+      ..color = const Color(0x99FFFFFF)
+      ..strokeWidth = 3
+      ..style = PaintingStyle.stroke;
+
+    final Paint fillPaint = Paint()
+      ..color = const Color(0x4D000000)
+      ..style = PaintingStyle.fill;
+
+    final double centerX = size.width / 2;
+    // 由於使用者希望人形示意圖更加貼近畫面底部，改以底部對齊的方式計算基準高度
+    final double overlayWidth = size.width * 0.7;
+    final double overlayHeight = size.height * 0.6;
+    final double overlayBottom = size.height * 0.92; // 保留 8% 的底部邊界避免被裁切
+    final Rect overlayRect = Rect.fromLTWH(
+      centerX - overlayWidth / 2,
+      overlayBottom - overlayHeight,
+      overlayWidth,
+      overlayHeight,
+    );
+    final double baseY = overlayRect.bottom - size.height * 0.04; // 腳部靠近底部，但仍預留安全距
+    final double figureHeight = size.height * 0.35;
+    final double headRadius = figureHeight * 0.12;
+
+    // ---------- 畫出半透明底框，淡化鏡頭畫面並突顯指引 ----------
+    canvas.drawRRect(
+      RRect.fromRectAndRadius(overlayRect, const Radius.circular(24)),
+      fillPaint,
+    );
+
+    // ---------- 定義左右人形的關鍵點 ----------
+    void drawFigure(bool isLeft) {
+      final double direction = isLeft ? -1 : 1; // 控制左右翻轉
+      final double torsoX = centerX + (size.width * 0.18 * direction);
+      final double headCenterY = baseY - figureHeight;
+      final Offset headCenter = Offset(torsoX, headCenterY);
+
+      // 頭部
+      canvas.drawCircle(headCenter, headRadius, guidelinePaint);
+
+      // 身體與腿部
+      final Offset hip = Offset(torsoX, baseY - headRadius);
+      final Offset knee = Offset(torsoX + direction * headRadius * 0.6, baseY - headRadius * 0.4);
+      final Offset foot = Offset(torsoX + direction * headRadius * 1.4, baseY);
+      canvas.drawLine(headCenter.translate(0, headRadius), hip, guidelinePaint);
+      canvas.drawLine(hip, knee, guidelinePaint);
+      canvas.drawLine(knee, foot, guidelinePaint);
+
+      // 手臂與球桿
+      final Offset shoulder = headCenter.translate(0, headRadius * 1.4);
+      final Offset hand = Offset(centerX + direction * headRadius * 1.8, baseY - headRadius * 0.8);
+      final Offset clubHead = Offset(centerX + direction * headRadius * 3.2, baseY + headRadius * 0.4);
+      canvas.drawLine(shoulder, hand, guidelinePaint);
+      canvas.drawLine(hand, clubHead, guidelinePaint);
+    }
+
+    drawFigure(true);
+    drawFigure(false);
+
+    // ---------- 畫出中央球與箭頭指引 ----------
+    final double ballRadius = headRadius * 0.9;
+    final Offset ballCenter = Offset(centerX, baseY - ballRadius * 0.2);
+    canvas.drawCircle(ballCenter, ballRadius, guidelinePaint);
+
+    final Path arrowPath = Path()
+      ..moveTo(centerX, ballCenter.dy - ballRadius * 1.4)
+      ..lineTo(centerX, ballCenter.dy - ballRadius * 3)
+      ..moveTo(centerX - ballRadius * 0.9, ballCenter.dy - ballRadius * 2.2)
+      ..lineTo(centerX, ballCenter.dy - ballRadius * 3)
+      ..lineTo(centerX + ballRadius * 0.9, ballCenter.dy - ballRadius * 2.2);
+    canvas.drawPath(arrowPath, guidelinePaint);
+
+    // ---------- 在頂部顯示指引文字 ----------
+    const String tip = '請對齊站位指引，確保雙腳與球心對稱';
+    final TextPainter textPainter = TextPainter(
+      text: const TextSpan(
+        text: tip,
+        style: TextStyle(
+          color: Colors.white,
+          fontSize: 16,
+          fontWeight: FontWeight.w600,
+          shadows: [Shadow(blurRadius: 6, color: Colors.black45, offset: Offset(0, 1))],
+        ),
+      ),
+      textAlign: TextAlign.center,
+      textDirection: TextDirection.ltr,
+    )..layout(maxWidth: size.width * 0.8);
+
+    textPainter.paint(
+      canvas,
+      Offset(centerX - textPainter.width / 2, overlayRect.top + 16),
+    );
+  }
+
+  @override
+  bool shouldRepaint(covariant CustomPainter oldDelegate) => false;
+}
+
+/// 影片播放頁面，提供錄製檔案的立即檢視
+class VideoPlayerPage extends StatefulWidget {
+  final String videoPath; // 影片檔案路徑
+  const VideoPlayerPage({super.key, required this.videoPath});
+
+  @override
+  State<VideoPlayerPage> createState() => _VideoPlayerPageState();
+}
+
+class _VideoPlayerPageState extends State<VideoPlayerPage> {
+  late VideoPlayerController _videoController;
+  static const String _shareMessage = '分享我的 TekSwing 揮桿影片'; // 分享時的預設文案
+
+  // ---------- 分享相關方法區 ----------
+  Future<void> _shareToTarget(_ShareTarget target) async {
+    // 事前確認檔案是否存在，避免分享流程出現例外
+    final file = File(widget.videoPath);
+    if (!await file.exists()) {
+      if (mounted) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          const SnackBar(content: Text('找不到影片檔案，無法分享。')),
+        );
+      }
+      return;
+    }
+
+    // 依目標應用程式取得對應的封裝名稱
+    final packageName = switch (target) {
+      _ShareTarget.instagram => 'com.instagram.android',
+      _ShareTarget.facebook => 'com.facebook.katana',
+      _ShareTarget.line => 'jp.naver.line.android',
+    };
+
+    bool sharedByPackage = false; // 紀錄是否已成功透過指定應用分享
+    if (Platform.isAndroid) {
+      try {
+        final result = await _shareChannel.invokeMethod<bool>('shareToPackage', {
+          'packageName': packageName,
+          'filePath': widget.videoPath,
+          'mimeType': 'video/*',
+          'text': _shareMessage,
+        });
+        sharedByPackage = result ?? false;
+      } on PlatformException catch (error) {
+        debugPrint('[Share] Android 指定分享失敗：$error');
+      }
+    }
+
+    if (!sharedByPackage) {
+      if (mounted && Platform.isAndroid) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          const SnackBar(content: Text('未找到指定社群 App，已改用系統分享選單。')),
+        );
+      }
+      await Share.shareXFiles([
+        XFile(widget.videoPath),
+      ], text: _shareMessage);
+    }
+  }
+
+  Widget _buildShareButton({
+    required IconData icon,
+    required String label,
+    required Color color,
+    required _ShareTarget target,
+  }) {
+    // 建立統一樣式的分享按鈕，維持排版一致
+    return Expanded(
+      child: ElevatedButton.icon(
+        onPressed: () => _shareToTarget(target),
+        icon: Icon(icon),
+        label: Text(label),
+        style: ElevatedButton.styleFrom(
+          backgroundColor: color,
+          foregroundColor: Colors.white,
+          padding: const EdgeInsets.symmetric(vertical: 12),
+        ),
+      ),
+    );
+  }
+
+  @override
+  void initState() {
+    super.initState();
+    _videoController = VideoPlayerController.file(File(widget.videoPath))
+      ..initialize().then((_) {
+        setState(() {});
+        _videoController.play();
+      });
+  }
+
+  @override
+  void dispose() {
+    _videoController.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('影片播放')),
+      body: Column(
+        children: [
+          Expanded(
+            child: Center(
+              child: _videoController.value.isInitialized
+                  ? AspectRatio(
+                      aspectRatio: _videoController.value.aspectRatio,
+                      child: VideoPlayer(_videoController),
+                    )
+                  : const CircularProgressIndicator(),
+            ),
+          ),
+          Padding(
+            padding: const EdgeInsets.fromLTRB(16, 8, 16, 24),
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.stretch,
+              children: [
+                const Text(
+                  '分享影片',
+                  style: TextStyle(fontSize: 16, fontWeight: FontWeight.bold),
+                ),
+                const SizedBox(height: 12),
+                Row(
+                  children: [
+                    _buildShareButton(
+                      icon: Icons.photo_camera,
+                      label: 'Instagram',
+                      color: const Color(0xFFC13584),
+                      target: _ShareTarget.instagram,
+                    ),
+                    const SizedBox(width: 12),
+                    _buildShareButton(
+                      icon: Icons.facebook,
+                      label: 'Facebook',
+                      color: const Color(0xFF1877F2),
+                      target: _ShareTarget.facebook,
+                    ),
+                    const SizedBox(width: 12),
+                    _buildShareButton(
+                      icon: Icons.chat,
+                      label: 'LINE',
+                      color: const Color(0xFF00C300),
+                      target: _ShareTarget.line,
+                    ),
+                  ],
+                ),
+                const SizedBox(height: 8),
+                const Text(
+                  '若無對應應用程式，將自動改用系統分享選單。',
+                  style: TextStyle(fontSize: 12, color: Colors.black54),
+                ),
+              ],
+            ),
+          ),
+        ],
+      ),
+      floatingActionButton: FloatingActionButton(
+        onPressed: () {
+          setState(() {
+            _videoController.value.isPlaying
+                ? _videoController.pause()
+                : _videoController.play();
+          });
+        },
+        child: Icon(_videoController.value.isPlaying ? Icons.pause : Icons.play_arrow),
+      ),
+    );
+  }
+}

--- a/lib/recorder_page.dart
+++ b/lib/recorder_page.dart
@@ -1,35 +1,3286 @@
+import 'dart:async';
+import 'dart:convert';
+import 'dart:developer' as developer; // 專責紀錄藍牙偵錯訊息
+import 'dart:io'; // 依平台動態決定權限需求
+
+import 'package:camera/camera.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart'; // 辨識平台層例外以補充權限提示
+import 'package:flutter_blue_plus/flutter_blue_plus.dart';
+import 'package:permission_handler/permission_handler.dart';
 
-/// 繪製音訊波形的畫家
-/// [waveform] 為聲音強度資料列表
-class WaveformPainter extends CustomPainter {
-  final List<double> waveform; // 波形資料
+import 'pages/recording_session_page.dart';
+import 'models/recording_history_entry.dart';
+import 'services/imu_data_logger.dart';
+import 'services/recording_history_storage.dart';
 
-  WaveformPainter(this.waveform);
+/// 錄影入口頁面：專責處理藍牙 IMU 配對與引導使用者前往錄影畫面
+class RecorderPage extends StatefulWidget {
+  final List<CameraDescription> cameras; // 傳入所有可用鏡頭
+  final List<RecordingHistoryEntry> initialHistory; // 外部帶入的歷史紀錄
+  final ValueChanged<List<RecordingHistoryEntry>> onHistoryChanged; // 回傳更新後的歷史資料
+
+  const RecorderPage({
+    super.key,
+    required this.cameras,
+    required this.initialHistory,
+    required this.onHistoryChanged,
+  });
 
   @override
-  void paint(Canvas canvas, Size size) {
-    // 綠色線條代表波形
-    final paint = Paint()
-      ..color = Colors.green
-      ..strokeWidth = 2.0;
+  State<RecorderPage> createState() => _RecorderPageState();
+}
 
-    // 計算畫布中線與縮放比例
-    final midY = size.height / 2;
-    final scaleX = size.width / waveform.length;
-    final scaleY = size.height / 2 / 160; // 假設 -160 dB 到 0 dB 範圍
+/// 定義 IMU 佩戴位置的插槽，方便多裝置管理
+enum _ImuSlotType { rightWrist, chest }
 
-    // 逐點連線描繪波形
-    for (int i = 0; i < waveform.length - 1; i++) {
-      final x1 = i * scaleX;
-      final y1 = midY - waveform[i] * scaleY;
-      final x2 = (i + 1) * scaleX;
-      final y2 = midY - waveform[i + 1] * scaleY;
-      canvas.drawLine(Offset(x1, y1), Offset(x2, y2), paint);
+extension _ImuSlotInfo on _ImuSlotType {
+  /// CSV 檔案名稱需使用英文字面固定格式
+  String get csvName => this == _ImuSlotType.rightWrist ? 'RIGHT_WRIST' : 'CHEST';
+
+  /// 顯示於 UI 的中文名稱
+  String get displayLabel => this == _ImuSlotType.rightWrist ? '右手腕 IMU' : '胸前 IMU';
+}
+
+class _RecorderPageState extends State<RecorderPage> {
+  void _logBle(String message, {Object? error, StackTrace? stackTrace}) {
+    // 集中處理藍牙相關紀錄，方便於 console 追蹤 bug
+    developer.log(
+      message,
+      name: 'BLE',
+      error: error,
+      stackTrace: stackTrace,
+    );
+  }
+
+  // ---------- 狀態變數區 ----------
+  StreamSubscription<List<ScanResult>>? _scanSubscription; // 藍牙掃描訂閱
+  StreamSubscription<BluetoothAdapterState>? _adapterStateSubscription; // 藍牙狀態監聽
+  StreamSubscription<BluetoothConnectionState>? _deviceConnectionSubscription; // 裝置連線狀態監聽
+  StreamSubscription<BluetoothConnectionState>? _secondDeviceConnectionSubscription; // 胸前 IMU 連線狀態監聽
+
+  BluetoothAdapterState _adapterState = BluetoothAdapterState.unknown; // 目前藍牙狀態
+  BluetoothDevice? _foundDevice; // 已搜尋到的目標 IMU 裝置
+  BluetoothDevice? _connectedDevice; // 已成功連線的 IMU 裝置（預設視為右手腕）
+  BluetoothConnectionState _connectionState =
+      BluetoothConnectionState.disconnected; // 右手腕 IMU 連線狀態
+  BluetoothDevice? _secondDevice; // 已成功連線的胸前 IMU 裝置
+  BluetoothConnectionState _secondConnectionState =
+      BluetoothConnectionState.disconnected; // 胸前 IMU 連線狀態
+
+  bool _isScanning = false; // 是否正在搜尋裝置
+  bool _isConnecting = false; // 是否正處於連線流程
+  bool _isOpeningSession = false; // 是否正在切換至錄影頁面
+  bool _permissionsReady = false; // 記錄藍牙權限是否已完整授權
+  late final Map<Permission, String> _runtimeBlePermissions; // 不同平台需申請的權限列表
+  int _selectedRounds = 5; // 使用者預設要錄影的次數
+  int _recordingDurationSeconds = 15; // 使用者預設每次錄影長度（秒）
+  String _connectionMessage = '尚未搜尋到 IMU 裝置'; // 右手腕 IMU 狀態文字
+  String _chestConnectionMessage = '尚未搜尋到胸前 IMU 裝置'; // 胸前 IMU 狀態文字
+  int? _lastRssi; // 紀錄訊號強度供顯示
+  String? _foundDeviceName; // 掃描到的裝置名稱
+  final Map<String, _ImuScanCandidate> _scanCandidates = {}; // 目前掃描到的藍牙裝置列表
+  Completer<void>? _activeScanStopper; // 追蹤目前掃描流程以便在外部中止等待
+  final Guid _nordicUartServiceUuid =
+      Guid('6E400001-B5A3-F393-E0A9-E50E24DCCA9E'); // 依 Nordic UART 定義的服務 UUID
+  final Guid _serviceBno086Uuid =
+      Guid('bac2f121-a97d-4a77-b2d3-8e46e87862ab'); // BNO086 感測器服務 UUID
+  final Guid _charLinearAccelerationUuid =
+      Guid('7e807164-3f0b-4252-9cb0-41241af264f0'); // 線性加速度特徵值
+  final Guid _charGameRotationVectorUuid =
+      Guid('07afa8e1-a1c8-48c8-9f5b-102c21261901'); // Game Rotation Vector 特徵值
+  final Guid _serviceButtonUuid =
+      Guid('d9087473-1415-44f0-bae8-1cd97fb224a5'); // 裝置按鈕服務 UUID
+  final Guid _charButtonNotifyUuid =
+      Guid('4a5a11ad-3f06-4de4-a56e-abd6e974a0ab'); // 按鈕事件通知特徵值
+  final Guid _serviceMotorUuid =
+      Guid('7c2b4a96-bf0a-444b-b1cd-559b5e36dd6f'); // 震動馬達服務 UUID
+  final Guid _charMotorToggleUuid =
+      Guid('ce12d81f-1325-4e02-82f0-c3e4f9896233'); // 震動馬達開關特徵值
+  final Guid _serviceBatteryUuid = Guid('0000180f-0000-1000-8000-00805f9b34fb'); // 電池服務 UUID
+  final Guid _charBatteryLevelUuid = Guid('00002a19-0000-1000-8000-00805f9b34fb'); // 電量百分比
+  final Guid _charBatteryVoltageUuid = Guid('0000f001-0000-1000-8000-00805f9b34fb'); // 電壓
+  final Guid _charBatteryChargeCurrentUuid = Guid('0000f002-0000-1000-8000-00805f9b34fb'); // 充電電流
+  final Guid _charBatteryTemperatureUuid = Guid('0000f003-0000-1000-8000-00805f9b34fb'); // 溫度
+  final Guid _charBatteryRemainingUuid = Guid('0000f004-0000-1000-8000-00805f9b34fb'); // 剩餘電量 mAh
+  final Guid _charBatteryTimeToEmptyUuid = Guid('0000f005-0000-1000-8000-00805f9b34fb'); // 用完時間
+  final Guid _charBatteryTimeToFullUuid = Guid('0000f006-0000-1000-8000-00805f9b34fb'); // 充滿時間
+  final Guid _serviceDeviceInfoUuid = Guid('0000180a-0000-1000-8000-00805f9b34fb'); // 標準裝置資訊服務
+  final Guid _charDeviceModelUuid = Guid('00002a24-0000-1000-8000-00805f9b34fb'); // 型號
+  final Guid _charDeviceSerialUuid = Guid('00002a25-0000-1000-8000-00805f9b34fb'); // 序號
+  final Guid _charFirmwareRevisionUuid = Guid('00002a26-0000-1000-8000-00805f9b34fb'); // 韌體版本
+  final Guid _charHardwareRevisionUuid = Guid('00002a27-0000-1000-8000-00805f9b34fb'); // 硬體版本
+  final Guid _charSoftwareRevisionUuid = Guid('00002a28-0000-1000-8000-00805f9b34fb'); // 軟體版本
+  final Guid _charManufacturerUuid = Guid('00002a29-0000-1000-8000-00805f9b34fb'); // 製造商
+  final Guid _serviceDeviceNameUuid =
+      Guid('3ab441e7-11f8-4bbc-a004-7716126c8868'); // 自訂裝置名稱服務
+  final Guid _charDeviceNameConfigUuid =
+      Guid('1b18c3ee-013a-4cb1-9923-95dc798de376'); // 自訂裝置名稱特徵值
+  final Guid _cccdUuid = Guid('00002902-0000-1000-8000-00805f9b34fb'); // 通知控制描述符 UUID
+  final List<StreamSubscription<List<int>>> _notificationSubscriptions =
+      []; // 右手腕感測通知訂閱
+  final List<StreamSubscription<List<int>>> _secondNotificationSubscriptions =
+      []; // 胸前感測通知訂閱
+  BluetoothCharacteristic? _linearAccelerationCharacteristic; // 線性加速度特徵引用
+  BluetoothCharacteristic? _gameRotationVectorCharacteristic; // Game Rotation Vector 特徵引用
+  BluetoothCharacteristic? _secondLinearAccelerationCharacteristic; // 胸前線性加速度特徵引用
+  BluetoothCharacteristic? _secondGameRotationVectorCharacteristic; // 胸前 Game Rotation Vector 特徵引用
+  BluetoothCharacteristic? _buttonNotifyCharacteristic; // 按鈕事件特徵引用（右手腕專用）
+  BluetoothCharacteristic? _motorControlCharacteristic; // 右手腕震動馬達控制特徵
+  BluetoothCharacteristic? _secondMotorControlCharacteristic; // 胸前震動馬達控制特徵
+  BluetoothCharacteristic? _batteryLevelCharacteristic; // 電量特徵引用
+  BluetoothCharacteristic? _batteryVoltageCharacteristic; // 電壓特徵引用
+  BluetoothCharacteristic? _batteryChargeCurrentCharacteristic; // 充電電流特徵引用
+  BluetoothCharacteristic? _batteryTemperatureCharacteristic; // 溫度特徵引用
+  BluetoothCharacteristic? _batteryRemainingCharacteristic; // 剩餘電量特徵引用
+  BluetoothCharacteristic? _batteryTimeToEmptyCharacteristic; // 用完時間特徵引用
+  BluetoothCharacteristic? _batteryTimeToFullCharacteristic; // 充滿時間特徵引用
+  BluetoothCharacteristic? _deviceModelCharacteristic; // 型號資訊特徵引用
+  BluetoothCharacteristic? _deviceSerialCharacteristic; // 序號資訊特徵引用
+  BluetoothCharacteristic? _firmwareRevisionCharacteristic; // 韌體版本特徵引用
+  BluetoothCharacteristic? _hardwareRevisionCharacteristic; // 硬體版本特徵引用
+  BluetoothCharacteristic? _softwareRevisionCharacteristic; // 軟體版本特徵引用
+  BluetoothCharacteristic? _manufacturerCharacteristic; // 製造商資訊特徵引用
+  BluetoothCharacteristic? _deviceNameCharacteristic; // 自訂裝置名稱特徵引用
+  Map<String, dynamic>? _latestLinearAcceleration; // 右手腕線性加速度資料
+  Map<String, dynamic>? _latestGameRotationVector; // 右手腕 Game Rotation Vector 資料
+  Map<String, dynamic>? _secondLatestLinearAcceleration; // 胸前線性加速度資料
+  Map<String, dynamic>? _secondLatestGameRotationVector; // 胸前 Game Rotation Vector 資料
+  Timer? _gameRotationFallbackTimer; // 右手腕 Game Rotation Vector 補償讀取計時器
+  bool _isGameRotationFallbackReading = false; // 避免補償讀取重入
+  DateTime? _lastGameRotationUpdate; // 右手腕最近一次 Game Rotation Vector 時間
+  int? _lastGameRotationSeq; // 右手腕 Game Rotation Vector 序號
+  int? _lastGameRotationTimestamp; // 右手腕 Game Rotation Vector 時間戳
+  Timer? _secondGameRotationFallbackTimer; // 胸前 Game Rotation Vector 補償讀取計時器
+  bool _isSecondGameRotationFallbackReading = false; // 胸前補償讀取重入保護
+  DateTime? _secondLastGameRotationUpdate; // 胸前最近一次 Game Rotation Vector 時間
+  int? _secondLastGameRotationSeq; // 胸前 Game Rotation Vector 序號
+  int? _secondLastGameRotationTimestamp; // 胸前 Game Rotation Vector 時間戳
+  String _buttonStatusText = '尚未接收到按鈕事件'; // 最近一次按鈕敘述
+  int? _buttonClickTimes; // 最近一次按鈕連擊次數
+  int? _buttonEventCode; // 最近一次按鈕事件代碼
+  DateTime? _lastButtonEventTime; // 最近一次按鈕事件時間
+  DateTime? _lastButtonTriggerTime; // 最近一次透過按鈕自動開啟錄影的時間
+  String? _batteryLevelText; // 電量百分比顯示
+  String? _batteryVoltageText; // 電壓顯示
+  String? _batteryChargeCurrentText; // 充電電流顯示
+  String? _batteryTemperatureText; // 溫度顯示
+  String? _batteryRemainingText; // 剩餘電量顯示
+  String? _batteryTimeToEmptyText; // 用完時間顯示
+  String? _batteryTimeToFullText; // 充滿時間顯示
+  String? _deviceModelName; // 裝置型號顯示
+  String? _deviceSerialNumber; // 裝置序號顯示
+  String? _firmwareRevision; // 韌體版本顯示
+  String? _hardwareRevision; // 硬體版本顯示
+  String? _softwareRevision; // 軟體版本顯示
+  String? _manufacturerName; // 製造商顯示
+  String? _customDeviceName; // 自訂裝置名稱顯示
+  bool _isTriggeringRightMotor = false; // 右手腕震動是否進行中
+  bool _isTriggeringChestMotor = false; // 胸前震動是否進行中
+  late final List<RecordingHistoryEntry> _recordingHistory =
+      List<RecordingHistoryEntry>.from(widget.initialHistory); // 累積曾經錄影的檔案資訊
+  final _BleOperationQueue _bleOperationQueue =
+      _BleOperationQueue(); // 排程 BLE 寫入請求，避免同時寫入造成忙碌錯誤
+  final StreamController<void> _imuButtonController = StreamController<void>.broadcast();
+  // IMU 按鈕事件廣播器，讓錄影頁面可以同步收到硬體按鈕觸發
+  bool _isSessionPageVisible = false; // 是否已顯示錄影頁面，避免重複開啟
+
+  // ---------- 生命週期 ----------
+  @override
+  void initState() {
+    super.initState();
+    unawaited(_restorePersistedHistory()); // 優先同步既有歷史，避免清單被清空
+    _runtimeBlePermissions = _resolveRuntimeBlePermissions(); // 先針對平台建立權限清單
+    _permissionsReady = _runtimeBlePermissions.isEmpty; // 若平台無需額外權限則直接視為已備妥
+    initBluetooth(); // 啟動藍牙權限申請與自動搜尋流程
+  }
+
+  /// 從本機檔案還原歷史紀錄，確保重整頁面後資料仍存在
+  Future<void> _restorePersistedHistory() async {
+    final stored = await RecordingHistoryStorage.instance.loadHistory();
+    if (!mounted) return;
+
+    if (stored.isEmpty) {
+      return; // 本地沒有紀錄時維持原狀，避免誤清空記憶中的清單
     }
+
+    final currentPaths = _recordingHistory.map((e) => e.filePath).toList();
+    final storedPaths = stored.map((e) => e.filePath).toList();
+    final isSameLength = currentPaths.length == storedPaths.length;
+    var isSameOrder = isSameLength;
+    if (isSameOrder) {
+      for (var i = 0; i < currentPaths.length; i++) {
+        if (currentPaths[i] != storedPaths[i]) {
+          isSameOrder = false;
+          break;
+        }
+      }
+    }
+
+    if (isSameOrder) {
+      return; // 若內容一致則不重複觸發重繪
+    }
+
+    setState(() {
+      _recordingHistory
+        ..clear()
+        ..addAll(stored);
+    });
+    widget.onHistoryChanged(List<RecordingHistoryEntry>.from(_recordingHistory));
   }
 
   @override
-  bool shouldRepaint(CustomPainter oldDelegate) => true;
+  void dispose() {
+    _scanSubscription?.cancel();
+    _adapterStateSubscription?.cancel();
+    _deviceConnectionSubscription?.cancel();
+    _secondDeviceConnectionSubscription?.cancel();
+    if (_activeScanStopper != null && !_activeScanStopper!.isCompleted) {
+      // 若仍有掃描流程在等待，主動結束避免懸掛 Future
+      _activeScanStopper!.complete();
+    }
+    if (_connectedDevice != null) {
+      ImuDataLogger.instance.unregisterDevice(_connectedDevice!.remoteId.str);
+    }
+    if (_secondDevice != null) {
+      ImuDataLogger.instance.unregisterDevice(_secondDevice!.remoteId.str);
+    }
+    unawaited(_clearImuSession()); // 統一釋放所有藍牙訂閱與特徵引用
+    unawaited(_clearSecondImuSession()); // 同步釋放第二顆 IMU 的資源
+    FlutterBluePlus.stopScan();
+    _bleOperationQueue.dispose(); // 中止尚未執行的 BLE 任務，避免頁面離開後仍呼叫底層 API
+    _imuButtonController.close(); // 關閉按鈕事件廣播，避免記憶體洩漏
+    super.dispose();
+  }
+
+  // ---------- 初始化流程 ----------
+  /// 初始化藍牙狀態與權限，確保錄影前完成 IMU 配對
+  Future<void> initBluetooth() async {
+    _logBle('初始化藍牙流程');
+    final permissionReady = await _requestBluetoothPermissions();
+    if (!permissionReady) {
+      // 權限不足時直接更新提示，避免進入掃描流程不斷拋錯
+      if (mounted) {
+        setState(() {
+          _connectionMessage = '請先授權藍牙與定位權限後再開始搜尋';
+        });
+      }
+      _logBle('初始化藍牙流程：權限未完全授權，暫停後續掃描');
+    }
+
+    // 監聽手機藍牙開關狀態，並視情況重新觸發掃描
+    _adapterStateSubscription = FlutterBluePlus.adapterState.listen((state) {
+      if (!mounted) return;
+      setState(() {
+        _adapterState = state;
+        if (state == BluetoothAdapterState.off) {
+          _connectedDevice = null;
+          _connectionState = BluetoothConnectionState.disconnected;
+          _connectionMessage = '請開啟藍牙以搜尋裝置';
+        }
+      });
+      _logBle('藍牙狀態變更：$state');
+
+      if (state == BluetoothAdapterState.on && !isImuConnected && !_isScanning && !_isConnecting) {
+        scanForImu();
+      }
+    });
+
+    final initialState = await FlutterBluePlus.adapterState.first;
+    if (!mounted) return;
+    setState(() => _adapterState = initialState);
+    _logBle('取得當前藍牙狀態：$initialState');
+
+    final connectedDevices = FlutterBluePlus.connectedDevices;
+    if (!mounted) return;
+
+    _logBle('系統回報已連線裝置數量：${connectedDevices.length}');
+
+    for (final device in connectedDevices) {
+      final services = await device.discoverServices();
+      if (!_containsImuService(services)) {
+        _logBle('啟動時略過裝置：${device.remoteId} 未包含 IMU 服務');
+        continue;
+      }
+      if (_connectedDevice == null) {
+        _connectedDevice = device;
+        _listenConnectionState(device);
+        ImuDataLogger.instance.registerDevice(
+          device,
+          displayName: _resolveDeviceName(device),
+          slotAlias: _ImuSlotType.rightWrist.csvName,
+        );
+        await _setupPrimaryImuServices(services);
+        if (!mounted) return;
+        setState(() {
+          _connectionState = BluetoothConnectionState.connected;
+          _connectionMessage = '已連線至 ${_resolveDeviceName(device)}';
+        });
+        _logBle('啟動時即偵測到右手腕 IMU：${_resolveDeviceName(device)}');
+        continue;
+      }
+
+      if (_secondDevice == null) {
+        _secondDevice = device;
+        _listenSecondConnectionState(device);
+        ImuDataLogger.instance.registerDevice(
+          device,
+          displayName: _resolveDeviceName(device),
+          slotAlias: _ImuSlotType.chest.csvName,
+        );
+        await _setupSecondImuServices(services);
+        if (!mounted) return;
+        setState(() {
+          _secondConnectionState = BluetoothConnectionState.connected;
+          _chestConnectionMessage = '已連線至 ${_resolveDeviceName(device)}';
+        });
+        _logBle('啟動時即偵測到胸前 IMU：${_resolveDeviceName(device)}');
+      }
+    }
+
+    if (initialState == BluetoothAdapterState.on) {
+      await scanForImu();
+    } else {
+      setState(() {
+        _connectionMessage = '請先開啟藍牙功能後再開始搜尋';
+      });
+    }
+  }
+
+  /// 申請藍牙與定位權限，避免掃描過程被拒
+  Future<bool> _requestBluetoothPermissions() async {
+    if (_runtimeBlePermissions.isEmpty) {
+      _logBle('當前平台無需額外藍牙權限，直接進入掃描流程');
+      _permissionsReady = true;
+      return true;
+    }
+
+    bool allGranted = true; // 記錄是否全部授權
+
+    for (final entry in _runtimeBlePermissions.entries) {
+      final permission = entry.key;
+      final label = entry.value;
+      final status = await permission.request();
+
+      // 詳細紀錄授權結果，方便在 console 中比對裝置設定
+      _logBle('權限請求結果：$label -> $status');
+
+      if (!_isPermissionStatusGranted(status)) {
+        allGranted = false;
+
+        if (status.isPermanentlyDenied) {
+          _logBle('權限 $label 被永久拒絕，需引導使用者前往系統設定');
+        }
+      }
+    }
+
+    if (!allGranted) {
+      _logBle('藍牙或定位權限尚未完整授權，將阻擋掃描流程');
+    }
+
+    _permissionsReady = allGranted;
+    return allGranted;
+  }
+
+  /// 依平台回傳需要申請的權限清單，避免要求不存在的藍牙權限
+  Map<Permission, String> _resolveRuntimeBlePermissions() {
+    if (Platform.isAndroid) {
+      return {
+        Permission.bluetoothScan: 'BLUETOOTH_SCAN',
+        Permission.bluetoothConnect: 'BLUETOOTH_CONNECT',
+        Permission.locationWhenInUse: 'ACCESS_FINE_LOCATION',
+      };
+    }
+
+    if (Platform.isIOS) {
+      return {
+        Permission.bluetooth: 'BLUETOOTH',
+        Permission.locationWhenInUse: 'LOCATION_WHEN_IN_USE',
+      };
+    }
+
+    return {
+      Permission.locationWhenInUse: 'ACCESS_FINE_LOCATION',
+    };
+  }
+
+  /// 將 limited / provisional 等同於已允許，避免誤判為拒絕
+  bool _isPermissionStatusGranted(PermissionStatus status) {
+    if (status.isGranted) {
+      return true;
+    }
+    return status == PermissionStatus.limited || status == PermissionStatus.provisional;
+  }
+
+  // ---------- 方法區 ----------
+  /// 掃描 TekSwing IMU 裝置並更新顯示資訊
+  Future<void> scanForImu() async {
+    if (_adapterState != BluetoothAdapterState.on) {
+      // 若藍牙尚未開啟則優先提示，避免重複觸發掃描與錯誤訊息
+      if (!mounted) return;
+      setState(() {
+        _connectionMessage = '請先開啟藍牙功能後再進行搜尋';
+      });
+      _logBle('掃描中止：手機藍牙尚未開啟');
+      return;
+    }
+
+    if (!_permissionsReady) {
+      final permissionReady = await _requestBluetoothPermissions();
+      if (!permissionReady) {
+        if (!mounted) return;
+        setState(() {
+          _connectionMessage = '權限不足，請確認已允許藍牙掃描與定位';
+        });
+        _logBle('掃描中止：權限不足');
+        return;
+      }
+    }
+
+    await _stopScan(resetFoundDevice: true); // 先停止前一次掃描，遵循 Nordic 範例先清除舊狀態
+
+    // 建立新的 completer，之後若外部主動停止掃描即可提前結束等待
+    _activeScanStopper = Completer<void>();
+
+    if (!mounted) return;
+    setState(() {
+      _isScanning = true;
+      _connectionMessage = '以低延遲模式掃描相容的 IMU 裝置...';
+      _scanCandidates.clear();
+    });
+    _logBle('開始掃描目標裝置，將掃描結果同步顯示於下方列表供使用者選擇');
+
+    _scanSubscription = FlutterBluePlus.scanResults.listen((results) {
+      if (!mounted || !_isScanning) {
+        return;
+      }
+
+      final Map<String, _ImuScanCandidate> updatedEntries = {};
+      bool hasUpdates = false;
+      BluetoothDevice? autoSelectDevice;
+      String? autoSelectName;
+      int? autoSelectRssi;
+
+      for (final result in results) {
+        final advertisement = result.advertisementData;
+        final advertisementName = advertisement.advName;
+        final deviceName = result.device.platformName;
+        final displayName = deviceName.isNotEmpty
+            ? deviceName
+            : (advertisementName.isNotEmpty ? advertisementName : '未命名裝置');
+        final matchesImuService = _isImuAdvertisement(advertisement);
+
+        final candidate = _ImuScanCandidate(
+          device: result.device,
+          displayName: displayName,
+          rssi: result.rssi,
+          matchesImuService: matchesImuService,
+          lastSeen: DateTime.now(),
+        );
+        final id = result.device.remoteId.str;
+        updatedEntries[id] = candidate;
+
+        final existing = _scanCandidates[id];
+        if (existing == null || existing.shouldUpdate(candidate)) {
+          hasUpdates = true;
+          _logBle(
+              '掃描結果更新：$displayName (${result.device.remoteId.str}) RSSI=${result.rssi}，符合服務=$matchesImuService');
+        }
+
+        if (matchesImuService &&
+            (_foundDevice == null ||
+                _foundDevice?.remoteId == result.device.remoteId)) {
+          autoSelectDevice = result.device;
+          autoSelectName = displayName;
+          autoSelectRssi = result.rssi;
+        }
+      }
+
+      if ((hasUpdates || autoSelectDevice != null) && mounted) {
+        setState(() {
+          for (final entry in updatedEntries.entries) {
+            _scanCandidates[entry.key] = entry.value;
+          }
+          if (autoSelectDevice != null) {
+            _foundDevice = autoSelectDevice;
+            _foundDeviceName = autoSelectName;
+            _lastRssi = autoSelectRssi;
+            _connectionMessage =
+                '偵測到 ${autoSelectName ?? 'IMU 裝置'}，請點擊配對裝置以建立連線';
+          }
+        });
+      }
+    }, onError: (error) {
+      if (!mounted) return;
+      setState(() {
+        _connectionMessage = '搜尋失敗：$error';
+      });
+      _logBle('掃描流程發生錯誤', error: error);
+      if (_activeScanStopper != null && !_activeScanStopper!.isCompleted) {
+        _activeScanStopper!.completeError(error);
+      }
+    });
+
+    try {
+      await FlutterBluePlus.startScan(
+        timeout: const Duration(seconds: 12),
+        // 依 Nordic Android Library 建議使用低延遲掃描模式以提升連線準備速度
+        androidScanMode: AndroidScanMode.lowLatency,
+      );
+      _logBle('已向系統請求開始掃描，等待裝置回應');
+
+      // 最多等待 12 秒或直到外部主動停止掃描，避免掃描流程無限等待
+      if (_activeScanStopper != null) {
+        await Future.any([
+          Future.delayed(const Duration(seconds: 12)),
+          _activeScanStopper!.future,
+        ]);
+      } else {
+        await Future.delayed(const Duration(seconds: 12));
+      }
+    } catch (e, stackTrace) {
+      if (!mounted) return;
+      setState(() {
+        _connectionMessage = '無法開始掃描或找不到裝置：$e';
+      });
+      _logBle('掃描流程例外：$e', error: e, stackTrace: stackTrace);
+
+      // 針對常見的權限錯誤補充更清楚的提示
+      if (e is PlatformException &&
+          e.code == 'startScan' &&
+          (e.message?.contains('BLUETOOTH_SCAN') ?? false)) {
+        _logBle('掃描流程例外：缺少 BLUETOOTH_SCAN 權限，提醒使用者前往系統設定開啟');
+        if (mounted) {
+          setState(() {
+            _connectionMessage = '系統顯示缺少藍牙掃描權限，請至設定授權後再試';
+          });
+        }
+      }
+    } finally {
+      await _stopScan();
+      _activeScanStopper = null;
+      if (!mounted) return;
+      setState(() {
+        _isScanning = false;
+        if (_scanCandidates.isEmpty) {
+          _connectionMessage = '未找到符合條件的裝置，請確認 IMU 已開機並靠近手機';
+        }
+      });
+      _logBle('掃描流程結束，已重置狀態');
+    }
+  }
+
+  /// 嘗試連線到掃描到的 IMU 裝置，並遵循 Nordic BLE Library 建議的手動連線流程
+  Future<void> connectToImu({
+    _ImuSlotType slot = _ImuSlotType.rightWrist,
+    BluetoothDevice? candidate,
+    String? candidateName,
+  }) async {
+    final target = candidate ??
+        (slot == _ImuSlotType.rightWrist
+            ? (_foundDevice ?? _connectedDevice)
+            : _secondDevice);
+    if (target == null) {
+      await scanForImu();
+      return;
+    }
+
+    final displayName = candidateName ?? _resolveDeviceName(target);
+
+    await _stopScan();
+
+    if (!mounted) return;
+    setState(() {
+      _isConnecting = true;
+      if (slot == _ImuSlotType.rightWrist) {
+        _connectionMessage = '正在與 $displayName 建立連線...';
+      } else {
+        _chestConnectionMessage = '正在與 $displayName 建立連線...';
+      }
+    });
+    _logBle('準備連線至 ${slot.displayLabel}：$displayName');
+
+    try {
+      await target.disconnect();
+    } catch (_) {
+      _logBle('預斷線時裝置可能未連線，忽略錯誤');
+    }
+
+    if (slot == _ImuSlotType.rightWrist && _connectedDevice != null) {
+      ImuDataLogger.instance.unregisterDevice(_connectedDevice!.remoteId.str);
+    }
+    if (slot == _ImuSlotType.chest && _secondDevice != null) {
+      ImuDataLogger.instance.unregisterDevice(_secondDevice!.remoteId.str);
+    }
+
+    if (slot == _ImuSlotType.rightWrist) {
+      await _clearImuSession();
+    } else {
+      await _clearSecondImuSession();
+    }
+
+    try {
+      await target.connect(
+        timeout: const Duration(seconds: 12),
+        autoConnect: false,
+      );
+      _logBle('已送出連線請求，等待裝置回覆');
+
+      await target.connectionState.firstWhere(
+        (state) => state == BluetoothConnectionState.connected,
+      );
+      _logBle('裝置狀態已回報連線，開始探索服務');
+      final services = await target.discoverServices();
+
+      try {
+        await target.requestMtu(247);
+        _logBle('MTU 調整成功，已設定為 247');
+      } catch (error, stackTrace) {
+        _logBle('MTU 調整失敗，裝置可能不支援：$error',
+            error: error, stackTrace: stackTrace);
+      }
+
+      if (slot == _ImuSlotType.rightWrist) {
+        _connectedDevice = target;
+        _listenConnectionState(target);
+        ImuDataLogger.instance.registerDevice(
+          target,
+          displayName: displayName,
+          slotAlias: slot.csvName,
+        );
+        await _setupPrimaryImuServices(services);
+        if (!mounted) return;
+        setState(() {
+          _connectionMessage = '已連線至 $displayName，右手腕感測資料就緒';
+        });
+      } else {
+        _secondDevice = target;
+        _listenSecondConnectionState(target);
+        ImuDataLogger.instance.registerDevice(
+          target,
+          displayName: displayName,
+          slotAlias: slot.csvName,
+        );
+        await _setupSecondImuServices(services);
+        if (!mounted) return;
+        setState(() {
+          _chestConnectionMessage = '已連線至 $displayName，胸前感測資料就緒';
+        });
+      }
+
+      _logBle('成功連線並完成服務初始化：${slot.displayLabel} -> $displayName');
+    } catch (e, stackTrace) {
+      if (!mounted) return;
+      setState(() {
+        if (slot == _ImuSlotType.rightWrist) {
+          _connectionMessage = '連線流程失敗：$e';
+          _connectedDevice = null;
+        } else {
+          _chestConnectionMessage = '連線流程失敗：$e';
+          _secondDevice = null;
+        }
+      });
+      if (slot == _ImuSlotType.rightWrist) {
+        await _clearImuSession(resetData: true);
+      } else {
+        await _clearSecondImuSession(resetData: true);
+      }
+      _logBle('連線流程發生例外：$e', error: e, stackTrace: stackTrace);
+      await _restartScanWithBackoff();
+    } finally {
+      if (!mounted) return;
+      setState(() {
+        _isConnecting = false;
+      });
+      _logBle('連線流程結束，已更新旗標狀態');
+    }
+  }
+
+  /// 停止掃描流程並視需求重置搜尋結果，避免背景掃描持續耗電
+  Future<void> _stopScan({bool resetFoundDevice = false}) async {
+    _logBle('停止掃描流程，reset=$resetFoundDevice');
+    if (_activeScanStopper != null && !_activeScanStopper!.isCompleted) {
+      // 若外部正在等待掃描結束，這裡主動完成等待，避免卡住 Future.any
+      _activeScanStopper!.complete();
+    }
+    await _scanSubscription?.cancel();
+    _scanSubscription = null;
+    await FlutterBluePlus.stopScan();
+    if (resetFoundDevice) {
+      _foundDevice = null;
+      _foundDeviceName = null;
+      _lastRssi = null;
+      _logBle('已清除先前掃描結果');
+    }
+  }
+
+  /// 掃描逾時或連線失敗時等待片刻再重試，模擬 Nordic 範例的退避策略
+  Future<void> _restartScanWithBackoff() async {
+    _logBle('啟動退避掃描策略，等待 2 秒後重試');
+    await Future.delayed(const Duration(seconds: 2));
+    if (!mounted || _isScanning || _isConnecting) {
+      _logBle('退避結束但目前無法重新掃描，mounted=$mounted、isScanning=$_isScanning、isConnecting=$_isConnecting');
+      return;
+    }
+    _logBle('重新啟動掃描流程');
+    await scanForImu();
+  }
+
+  /// 清除目前所有藍牙相關訂閱與狀態，確保重新連線時不會殘留舊資料
+  Future<void> _clearImuSession({bool resetData = false}) async {
+    _logBle('清理 IMU 連線會話，resetData=$resetData');
+    await _cancelNotificationSubscriptions();
+    _cancelGameRotationFallbackTimer();
+    _resetCharacteristicReferences();
+    if (resetData) {
+      if (mounted) {
+        setState(_resetImuDataState);
+      } else {
+        _resetImuDataState();
+      }
+    }
+  }
+
+  /// 清除第二顆 IMU 的連線資訊與感測訂閱
+  Future<void> _clearSecondImuSession({bool resetData = false}) async {
+    _logBle('清理第二顆 IMU 連線會話，resetData=$resetData');
+    await _cancelSecondNotificationSubscriptions();
+    _cancelSecondGameRotationFallbackTimer();
+    _resetSecondCharacteristicReferences();
+    if (resetData) {
+      if (mounted) {
+        setState(_resetSecondImuDataState);
+      } else {
+        _resetSecondImuDataState();
+      }
+    }
+  }
+
+  /// 逐一取消感測特徵的訂閱監聽，避免背景串流持續觸發
+  Future<void> _cancelNotificationSubscriptions() async {
+    _logBle('取消所有感測通知訂閱，共 ${_notificationSubscriptions.length} 筆');
+    for (final subscription in _notificationSubscriptions) {
+      await subscription.cancel();
+    }
+    _notificationSubscriptions.clear();
+  }
+
+  /// 取消胸前 IMU 的所有通知訂閱
+  Future<void> _cancelSecondNotificationSubscriptions() async {
+    _logBle('取消胸前 IMU 通知訂閱，共 ${_secondNotificationSubscriptions.length} 筆');
+    for (final subscription in _secondNotificationSubscriptions) {
+      await subscription.cancel();
+    }
+    _secondNotificationSubscriptions.clear();
+  }
+
+  /// 將所有特徵引用歸零，避免誤用已經失效的 characteristic 物件
+  void _resetCharacteristicReferences() {
+    _logBle('重置所有特徵引用，避免使用到舊連線物件');
+    _linearAccelerationCharacteristic = null;
+    _gameRotationVectorCharacteristic = null;
+    _buttonNotifyCharacteristic = null;
+    _motorControlCharacteristic = null;
+    _batteryLevelCharacteristic = null;
+    _batteryVoltageCharacteristic = null;
+    _batteryChargeCurrentCharacteristic = null;
+    _batteryTemperatureCharacteristic = null;
+    _batteryRemainingCharacteristic = null;
+    _batteryTimeToEmptyCharacteristic = null;
+    _batteryTimeToFullCharacteristic = null;
+    _deviceModelCharacteristic = null;
+    _deviceSerialCharacteristic = null;
+    _firmwareRevisionCharacteristic = null;
+    _hardwareRevisionCharacteristic = null;
+    _softwareRevisionCharacteristic = null;
+    _manufacturerCharacteristic = null;
+    _deviceNameCharacteristic = null;
+  }
+
+  /// 重置胸前 IMU 的特徵引用
+  void _resetSecondCharacteristicReferences() {
+    _secondLinearAccelerationCharacteristic = null;
+    _secondGameRotationVectorCharacteristic = null;
+    _secondMotorControlCharacteristic = null;
+  }
+
+  /// 重置所有感測顯示資料，讓 UI 反映目前沒有有效連線的狀態
+  void _resetImuDataState() {
+    _logBle('重置 IMU 顯示資料，等待重新連線');
+    _latestLinearAcceleration = null;
+    _latestGameRotationVector = null;
+    _lastGameRotationUpdate = null;
+    _lastGameRotationSeq = null;
+    _lastGameRotationTimestamp = null;
+    _buttonStatusText = '尚未接收到按鈕事件';
+    _buttonClickTimes = null;
+    _buttonEventCode = null;
+    _lastButtonEventTime = null;
+    _batteryLevelText = null;
+    _batteryVoltageText = null;
+    _batteryChargeCurrentText = null;
+    _batteryTemperatureText = null;
+    _batteryRemainingText = null;
+    _batteryTimeToEmptyText = null;
+    _batteryTimeToFullText = null;
+    _deviceModelName = null;
+    _deviceSerialNumber = null;
+    _firmwareRevision = null;
+    _hardwareRevision = null;
+    _softwareRevision = null;
+    _manufacturerName = null;
+    _customDeviceName = null;
+    _isTriggeringRightMotor = false;
+  }
+
+  /// 重置胸前 IMU 的顯示資料，主要影響 CSV 與除錯資訊
+  void _resetSecondImuDataState() {
+    _secondLatestLinearAcceleration = null;
+    _secondLatestGameRotationVector = null;
+    _secondLastGameRotationUpdate = null;
+    _secondLastGameRotationSeq = null;
+    _secondLastGameRotationTimestamp = null;
+    _isTriggeringChestMotor = false;
+  }
+
+  /// 依插槽取得對應的馬達控制特徵，方便共用判斷邏輯
+  BluetoothCharacteristic? _motorCharacteristicForSlot(_ImuSlotType slot) =>
+      slot == _ImuSlotType.rightWrist ? _motorControlCharacteristic : _secondMotorControlCharacteristic;
+
+  /// 檢查指定插槽是否仍在執行震動任務，避免重複送出寫入
+  bool _isMotorBusyForSlot(_ImuSlotType slot) =>
+      slot == _ImuSlotType.rightWrist ? _isTriggeringRightMotor : _isTriggeringChestMotor;
+
+  /// 更新震動狀態並同步考量元件是否仍掛載，確保不會在 dispose 後 setState
+  void _setMotorBusyForSlot(_ImuSlotType slot, bool value) {
+    if (!mounted) {
+      if (slot == _ImuSlotType.rightWrist) {
+        _isTriggeringRightMotor = value;
+      } else {
+        _isTriggeringChestMotor = value;
+      }
+      return;
+    }
+
+    setState(() {
+      if (slot == _ImuSlotType.rightWrist) {
+        _isTriggeringRightMotor = value;
+      } else {
+        _isTriggeringChestMotor = value;
+      }
+    });
+  }
+
+  /// 監聽裝置連線狀態，若中斷則重新搜尋
+  void _listenConnectionState(BluetoothDevice device) {
+    _deviceConnectionSubscription?.cancel();
+    _deviceConnectionSubscription = device.connectionState.listen((state) async {
+      if (!mounted) return;
+
+      if (state == BluetoothConnectionState.connected) {
+        setState(() {
+          _connectionState = state;
+          _connectedDevice = device;
+          _connectionMessage = '已連線至 ${_resolveDeviceName(device)}';
+        });
+        _logBle('裝置持續回報連線狀態：${_resolveDeviceName(device)}');
+        return;
+      }
+
+      if (state == BluetoothConnectionState.disconnected) {
+        await _clearImuSession(resetData: true);
+        ImuDataLogger.instance.unregisterDevice(device.remoteId.str);
+        if (!mounted) return;
+        setState(() {
+          _connectionState = state;
+          _connectedDevice = null;
+          _connectionMessage = '裝置已斷線，稍後自動重新搜尋';
+          _resetImuDataState();
+        });
+        _logBle('裝置連線中斷，準備重新掃描：${device.remoteId.str}');
+        _restartScanWithBackoff();
+        return;
+      }
+
+      setState(() {
+        _connectionState = state;
+      });
+      _logBle('裝置回報其他狀態：$state');
+    });
+  }
+
+  /// 監聽胸前 IMU 的連線狀態
+  void _listenSecondConnectionState(BluetoothDevice device) {
+    _secondDeviceConnectionSubscription?.cancel();
+    _secondDeviceConnectionSubscription = device.connectionState.listen((state) async {
+      if (!mounted) return;
+
+      if (state == BluetoothConnectionState.connected) {
+        setState(() {
+          _secondConnectionState = state;
+          _secondDevice = device;
+          _chestConnectionMessage = '已連線至 ${_resolveDeviceName(device)}';
+        });
+        _logBle('胸前裝置持續回報連線狀態：${_resolveDeviceName(device)}');
+        return;
+      }
+
+      if (state == BluetoothConnectionState.disconnected) {
+        await _clearSecondImuSession(resetData: true);
+        ImuDataLogger.instance.unregisterDevice(device.remoteId.str);
+        if (!mounted) return;
+        setState(() {
+          _secondConnectionState = state;
+          _secondDevice = null;
+          _chestConnectionMessage = '胸前裝置已斷線，稍後自動重新搜尋';
+          _resetSecondImuDataState();
+        });
+        _logBle('胸前裝置連線中斷，準備重新掃描：${device.remoteId.str}');
+        _restartScanWithBackoff();
+        return;
+      }
+
+      setState(() {
+        _secondConnectionState = state;
+      });
+      _logBle('胸前裝置回報其他狀態：$state');
+    });
+  }
+
+  /// 掃描完成後依據各個服務設定通知與初始值讀取，讓感測資料能即時更新
+  Future<void> _setupPrimaryImuServices(List<BluetoothService> services) async {
+    await _cancelNotificationSubscriptions();
+    _cancelGameRotationFallbackTimer();
+    _resetCharacteristicReferences();
+
+    if (mounted) {
+      setState(_resetImuDataState);
+    } else {
+      _resetImuDataState();
+    }
+
+    _logBle('開始建立 IMU 服務訂閱，共取得 ${services.length} 組服務');
+
+    for (final service in services) {
+      if (service.uuid == _serviceBno086Uuid) {
+        _logBle('匹配到 BNO086 感測服務');
+        for (final characteristic in service.characteristics) {
+          if (characteristic.uuid == _charLinearAccelerationUuid) {
+            _linearAccelerationCharacteristic = characteristic;
+            _logBle('已綁定線性加速度特徵：${characteristic.uuid.str}');
+          } else if (characteristic.uuid == _charGameRotationVectorUuid) {
+            _gameRotationVectorCharacteristic = characteristic;
+            _logBle('已綁定 Game Rotation Vector 特徵：${characteristic.uuid.str}');
+          }
+        }
+      } else if (service.uuid == _serviceButtonUuid) {
+        _logBle('匹配到按鈕事件服務');
+        for (final characteristic in service.characteristics) {
+          if (characteristic.uuid == _charButtonNotifyUuid) {
+            _buttonNotifyCharacteristic = characteristic;
+            _logBle('已綁定按鈕通知特徵：${characteristic.uuid.str}');
+          }
+        }
+      } else if (service.uuid == _serviceMotorUuid) {
+        _logBle('匹配到馬達控制服務');
+        for (final characteristic in service.characteristics) {
+          if (characteristic.uuid == _charMotorToggleUuid) {
+            _motorControlCharacteristic = characteristic;
+            _logBle('已綁定馬達控制特徵：${characteristic.uuid.str}');
+          }
+        }
+      } else if (service.uuid == _serviceBatteryUuid) {
+        _logBle('匹配到電池狀態服務');
+        for (final characteristic in service.characteristics) {
+          if (characteristic.uuid == _charBatteryLevelUuid) {
+            _batteryLevelCharacteristic = characteristic;
+            _logBle('已綁定電量特徵：${characteristic.uuid.str}');
+          } else if (characteristic.uuid == _charBatteryVoltageUuid) {
+            _batteryVoltageCharacteristic = characteristic;
+            _logBle('已綁定電壓特徵：${characteristic.uuid.str}');
+          } else if (characteristic.uuid == _charBatteryChargeCurrentUuid) {
+            _batteryChargeCurrentCharacteristic = characteristic;
+            _logBle('已綁定充電電流特徵：${characteristic.uuid.str}');
+          } else if (characteristic.uuid == _charBatteryTemperatureUuid) {
+            _batteryTemperatureCharacteristic = characteristic;
+            _logBle('已綁定電池溫度特徵：${characteristic.uuid.str}');
+          } else if (characteristic.uuid == _charBatteryRemainingUuid) {
+            _batteryRemainingCharacteristic = characteristic;
+            _logBle('已綁定剩餘電量特徵：${characteristic.uuid.str}');
+          } else if (characteristic.uuid == _charBatteryTimeToEmptyUuid) {
+            _batteryTimeToEmptyCharacteristic = characteristic;
+            _logBle('已綁定預估用完時間特徵：${characteristic.uuid.str}');
+          } else if (characteristic.uuid == _charBatteryTimeToFullUuid) {
+            _batteryTimeToFullCharacteristic = characteristic;
+            _logBle('已綁定預估充滿時間特徵：${characteristic.uuid.str}');
+          }
+        }
+      } else if (service.uuid == _serviceDeviceInfoUuid) {
+        _logBle('匹配到裝置資訊服務');
+        for (final characteristic in service.characteristics) {
+          if (characteristic.uuid == _charDeviceModelUuid) {
+            _deviceModelCharacteristic = characteristic;
+            _logBle('已綁定型號資訊特徵：${characteristic.uuid.str}');
+          } else if (characteristic.uuid == _charDeviceSerialUuid) {
+            _deviceSerialCharacteristic = characteristic;
+            _logBle('已綁定序號資訊特徵：${characteristic.uuid.str}');
+          } else if (characteristic.uuid == _charFirmwareRevisionUuid) {
+            _firmwareRevisionCharacteristic = characteristic;
+            _logBle('已綁定韌體版本特徵：${characteristic.uuid.str}');
+          } else if (characteristic.uuid == _charHardwareRevisionUuid) {
+            _hardwareRevisionCharacteristic = characteristic;
+            _logBle('已綁定硬體版本特徵：${characteristic.uuid.str}');
+          } else if (characteristic.uuid == _charSoftwareRevisionUuid) {
+            _softwareRevisionCharacteristic = characteristic;
+            _logBle('已綁定軟體版本特徵：${characteristic.uuid.str}');
+          } else if (characteristic.uuid == _charManufacturerUuid) {
+            _manufacturerCharacteristic = characteristic;
+            _logBle('已綁定製造商資訊特徵：${characteristic.uuid.str}');
+          }
+        }
+      } else if (service.uuid == _serviceDeviceNameUuid) {
+        _logBle('匹配到自訂名稱服務');
+        for (final characteristic in service.characteristics) {
+          if (characteristic.uuid == _charDeviceNameConfigUuid) {
+            _deviceNameCharacteristic = characteristic;
+            _logBle('已綁定自訂名稱特徵：${characteristic.uuid.str}');
+          }
+        }
+      }
+    }
+
+    if (_linearAccelerationCharacteristic == null ||
+        _gameRotationVectorCharacteristic == null ||
+        _buttonNotifyCharacteristic == null) {
+      _logBle('關鍵感測特徵缺失，請確認韌體是否支援最新規格', error: {
+        'linear': _linearAccelerationCharacteristic != null,
+        'rotation': _gameRotationVectorCharacteristic != null,
+        'button': _buttonNotifyCharacteristic != null,
+      });
+    }
+
+    if (_linearAccelerationCharacteristic != null) {
+      _logBle('準備訂閱線性加速度通知');
+      await _initCharacteristic(
+        characteristic: _linearAccelerationCharacteristic!,
+        onData: _handleLinearAccelerationPacket,
+      );
+    }
+
+    if (_gameRotationVectorCharacteristic != null) {
+      _logBle('準備訂閱 Game Rotation Vector 通知');
+      final characteristic = _gameRotationVectorCharacteristic!;
+      final isListening = await _initCharacteristic(
+        characteristic: characteristic,
+        onData: _handleGameRotationVectorPacket,
+        readInitialValue: false, // 避免裝置禁止讀取時立刻拋出例外
+      );
+      _startGameRotationFallbackTimer(
+        notificationActive: isListening,
+        canReadCharacteristic: characteristic.properties.read,
+      );
+    }
+
+    if (_buttonNotifyCharacteristic != null) {
+      _logBle('準備訂閱按鈕事件通知');
+      await _initCharacteristic(
+        characteristic: _buttonNotifyCharacteristic!,
+        onData: (_, value) => _handleButtonPacket(value),
+        listenToUpdates: true,
+        readInitialValue: false,
+      );
+    }
+
+    if (_batteryLevelCharacteristic != null) {
+      _logBle('準備讀取電池電量資訊');
+      await _initCharacteristic(
+        characteristic: _batteryLevelCharacteristic!,
+        onData: (_, value) => _updateBatteryLevel(value),
+        listenToUpdates: _batteryLevelCharacteristic!.properties.notify,
+      );
+    }
+
+    if (_batteryVoltageCharacteristic != null) {
+      _logBle('準備讀取電池電壓資訊');
+      await _initCharacteristic(
+        characteristic: _batteryVoltageCharacteristic!,
+        onData: (_, value) => _updateBatteryVoltage(value),
+        listenToUpdates: _batteryVoltageCharacteristic!.properties.notify,
+      );
+    }
+
+    if (_batteryChargeCurrentCharacteristic != null) {
+      _logBle('準備讀取充電電流資訊');
+      await _initCharacteristic(
+        characteristic: _batteryChargeCurrentCharacteristic!,
+        onData: (_, value) => _updateBatteryChargeCurrent(value),
+        listenToUpdates: _batteryChargeCurrentCharacteristic!.properties.notify,
+      );
+    }
+
+    if (_batteryTemperatureCharacteristic != null) {
+      _logBle('準備讀取電池溫度資訊');
+      await _initCharacteristic(
+        characteristic: _batteryTemperatureCharacteristic!,
+        onData: (_, value) => _updateBatteryTemperature(value),
+        listenToUpdates: _batteryTemperatureCharacteristic!.properties.notify,
+      );
+    }
+
+    if (_batteryRemainingCharacteristic != null) {
+      _logBle('準備讀取剩餘電量資訊');
+      await _initCharacteristic(
+        characteristic: _batteryRemainingCharacteristic!,
+        onData: (_, value) => _updateBatteryRemaining(value),
+        listenToUpdates: _batteryRemainingCharacteristic!.properties.notify,
+      );
+    }
+
+    if (_batteryTimeToEmptyCharacteristic != null) {
+      _logBle('準備讀取預估用完時間資訊');
+      await _initCharacteristic(
+        characteristic: _batteryTimeToEmptyCharacteristic!,
+        onData: (_, value) => _updateBatteryTimeToEmpty(value),
+        listenToUpdates: _batteryTimeToEmptyCharacteristic!.properties.notify,
+      );
+    }
+
+    if (_batteryTimeToFullCharacteristic != null) {
+      _logBle('準備讀取預估充滿時間資訊');
+      await _initCharacteristic(
+        characteristic: _batteryTimeToFullCharacteristic!,
+        onData: (_, value) => _updateBatteryTimeToFull(value),
+        listenToUpdates: _batteryTimeToFullCharacteristic!.properties.notify,
+      );
+    }
+
+    if (_deviceModelCharacteristic != null) {
+      _logBle('準備讀取裝置型號資訊');
+    }
+    await _readAndAssignString(
+      _deviceModelCharacteristic,
+      (value) => _deviceModelName = value,
+    );
+    if (_deviceSerialCharacteristic != null) {
+      _logBle('準備讀取序號資訊');
+    }
+    await _readAndAssignString(
+      _deviceSerialCharacteristic,
+      (value) => _deviceSerialNumber = value,
+    );
+    if (_firmwareRevisionCharacteristic != null) {
+      _logBle('準備讀取韌體版本');
+    }
+    await _readAndAssignString(
+      _firmwareRevisionCharacteristic,
+      (value) => _firmwareRevision = value,
+    );
+    if (_hardwareRevisionCharacteristic != null) {
+      _logBle('準備讀取硬體版本');
+    }
+    await _readAndAssignString(
+      _hardwareRevisionCharacteristic,
+      (value) => _hardwareRevision = value,
+    );
+    if (_softwareRevisionCharacteristic != null) {
+      _logBle('準備讀取軟體版本');
+    }
+    await _readAndAssignString(
+      _softwareRevisionCharacteristic,
+      (value) => _softwareRevision = value,
+    );
+    if (_manufacturerCharacteristic != null) {
+      _logBle('準備讀取製造商資訊');
+    }
+    await _readAndAssignString(
+      _manufacturerCharacteristic,
+      (value) => _manufacturerName = value,
+    );
+    if (_deviceNameCharacteristic != null) {
+      _logBle('準備讀取自訂名稱資訊');
+    }
+    await _readAndAssignString(
+      _deviceNameCharacteristic,
+      (value) => _customDeviceName = value,
+    );
+  }
+
+  /// 統一處理特徵值的通知與讀取邏輯，確保監聽與初始資料都能取得
+  ///
+  /// 回傳值代表是否成功維持通知監聽（true 表示已建立監聽，false 則僅執行讀取）
+  Future<bool> _enableNotificationWithRetry(
+    BluetoothCharacteristic characteristic,
+  ) async {
+    // ---------- 多次嘗試開啟通知 ----------
+    // 部分裝置剛連線時 CCCD 仍在初始化，直接呼叫 setNotifyValue 會被 GATT 拒絕。
+    // 這裡提供 3 次退避重試機制，確保在韌體就緒後仍能成功啟用通知。
+    const maxAttempts = 3;
+    for (var attempt = 0; attempt < maxAttempts; attempt++) {
+      var requireLongDelay = false; // 若收到忙碌訊號則增加等待時間
+      try {
+        // ---------- 排入序列化佇列 ----------
+        // Flutter 層同時對多個 CCCD 寫入時，Android 端會回報 BUSY。
+        // 透過佇列確保一次僅發出一個 setNotifyValue 呼叫，降低 writeDescriptor 忙碌機率。
+        await _bleOperationQueue.enqueue(
+          () async {
+            _logBle('排程啟用通知請求（第${attempt + 1}次）：${characteristic.uuid.str}');
+            await characteristic.setNotifyValue(true);
+          },
+          spacing: const Duration(milliseconds: 180), // 預留時間讓韌體處理前一筆 GATT 請求
+        );
+        _logBle('成功啟用通知（第${attempt + 1}次嘗試）：${characteristic.uuid.str}');
+        return true;
+      } on FlutterBluePlusException catch (error, stackTrace) {
+        // ---------- 解析 flutter_blue_plus 例外內容 ----------
+        // errorString 會帶有原生層回傳的描述字串，先轉為小寫方便判斷忙碌或權限類型。
+        final message = (error.errorString ?? '').toLowerCase();
+        if (message.contains('busy')) {
+          requireLongDelay = true;
+          _logBle('偵測到底層回報忙碌，將延後下次重試：${characteristic.uuid.str}');
+        }
+        _logBle(
+          '開啟通知失敗（FlutterBluePlusException，第${attempt + 1}次）：${characteristic.uuid.str} -> $error',
+          error: error,
+          stackTrace: stackTrace,
+        );
+      } on PlatformException catch (error, stackTrace) {
+        _logBle(
+          '開啟通知失敗（PlatformException，第${attempt + 1}次）：${characteristic.uuid.str} -> ${error.code}:${error.message}',
+          error: error,
+          stackTrace: stackTrace,
+        );
+        final lowerMessage = error.message?.toLowerCase() ?? '';
+        if (lowerMessage.contains('busy')) {
+          requireLongDelay = true;
+          _logBle('GATT 回應忙碌（${characteristic.uuid.str}），延長等待時間後再試');
+        }
+        if (lowerMessage.contains('not permitted') ||
+            lowerMessage.contains('not supported')) {
+          // ---------- GATT 明確拒絕 ----------
+          // 若韌體回報沒有通知權限，持續重試沒有意義，直接跳出等待補償機制。
+          _logBle('偵測到 GATT 拒絕通知，停止重試：${characteristic.uuid.str}');
+          return false;
+        }
+      } catch (error, stackTrace) {
+        _logBle(
+          '開啟通知發生未預期例外（第${attempt + 1}次）：${characteristic.uuid.str} -> $error',
+          error: error,
+          stackTrace: stackTrace,
+        );
+      }
+
+      if (attempt < maxAttempts - 1) {
+        final baseDelay = requireLongDelay ? 700 : 400;
+        final delay = Duration(milliseconds: baseDelay * (attempt + 1));
+        _logBle('通知啟用失敗，${delay.inMilliseconds}ms 後重試：${characteristic.uuid.str}');
+        await Future.delayed(delay);
+      }
+    }
+
+    _logBle('多次嘗試仍無法啟用通知，改採僅讀取模式：${characteristic.uuid.str}');
+    return false;
+  }
+
+  Future<bool> _initCharacteristic({
+    required BluetoothCharacteristic characteristic,
+    required void Function(String deviceId, List<int>) onData,
+    bool listenToUpdates = true,
+    bool readInitialValue = true,
+    List<StreamSubscription<List<int>>>? targetSubscriptions,
+    void Function(String message)? onErrorMessage,
+  }) async {
+    bool shouldListen =
+        listenToUpdates && (characteristic.properties.notify || characteristic.properties.indicate);
+
+    if (shouldListen) {
+      try {
+        if (characteristic.descriptors.isEmpty) {
+          // ---------- 某些裝置不會回報描述符 ----------
+          // 仍強制嘗試開啟通知，避免因缺少 CCCD 而錯失資料
+          _logBle('特徵 ${characteristic.uuid.str} 未附帶描述符，改以直接開啟通知');
+        } else {
+          final hasCccd =
+              characteristic.descriptors.any((descriptor) => descriptor.uuid == _cccdUuid);
+          if (!hasCccd) {
+            // ---------- 找不到 CCCD ----------
+            // 仍嘗試開啟通知，同時輸出除錯資訊方便排查韌體設定
+      _logBle('裝置未回傳 CCCD，改以直接開啟通知：${characteristic.uuid.str}');
+      }
+    }
+
+    if (!characteristic.isNotifying) {
+          // ---------- 尚未啟用通知，交給重試機制處理 ----------
+          shouldListen = await _enableNotificationWithRetry(characteristic);
+        } else {
+          // ---------- 避免重複啟用 ----------
+          _logBle('通知已開啟，略過重複設定：${characteristic.uuid.str}');
+        }
+      } catch (error, stackTrace) {
+        // 若裝置暫不支援通知則忽略錯誤，改以初始讀取補救
+        shouldListen = false;
+        _logBle('開啟通知失敗：${characteristic.uuid.str}，原因：$error',
+            error: error, stackTrace: stackTrace);
+      }
+    }
+
+    if (shouldListen) {
+      final deviceId = characteristic.remoteId.str;
+      final subscription = characteristic.lastValueStream.listen(
+        (value) => onData(deviceId, value),
+        onError: (error) {
+          if (!mounted) return;
+          if (onErrorMessage != null) {
+            onErrorMessage('讀取 ${characteristic.uuid.str} 時發生錯誤：$error');
+          } else {
+            setState(() {
+              _connectionMessage = '讀取 ${characteristic.uuid.str} 時發生錯誤：$error';
+            });
+          }
+          _logBle('特徵通知流錯誤：${characteristic.uuid.str}，錯誤：$error', error: error);
+        },
+      );
+      (targetSubscriptions ?? _notificationSubscriptions).add(subscription);
+    }
+
+    if (readInitialValue && characteristic.properties.read) {
+      try {
+        final value = await characteristic.read();
+        if (value.isNotEmpty) {
+          onData(characteristic.remoteId.str, value);
+        }
+        _logBle('已讀取初始值：${characteristic.uuid.str}，長度：${value.length}');
+      } catch (error, stackTrace) {
+        // 初始讀取失敗時暫不處理，等待後續通知補上資料
+        _logBle('初始讀取失敗：${characteristic.uuid.str}，原因：$error', error: error, stackTrace: stackTrace);
+      }
+    }
+    return shouldListen;
+  }
+
+  /// 建立胸前 IMU 的感測特徵訂閱
+  Future<void> _setupSecondImuServices(List<BluetoothService> services) async {
+    await _cancelSecondNotificationSubscriptions();
+    _cancelSecondGameRotationFallbackTimer();
+    _resetSecondCharacteristicReferences();
+    _resetSecondImuDataState();
+
+    _logBle('開始建立胸前 IMU 服務訂閱，共取得 ${services.length} 組服務');
+
+    for (final service in services) {
+      if (service.uuid == _serviceBno086Uuid) {
+        for (final characteristic in service.characteristics) {
+          if (characteristic.uuid == _charLinearAccelerationUuid) {
+            _secondLinearAccelerationCharacteristic = characteristic;
+            _logBle('胸前 IMU 綁定線性加速度特徵：${characteristic.uuid.str}');
+          } else if (characteristic.uuid == _charGameRotationVectorUuid) {
+            _secondGameRotationVectorCharacteristic = characteristic;
+            _logBle('胸前 IMU 綁定 Game Rotation Vector 特徵：${characteristic.uuid.str}');
+          }
+        }
+      } else if (service.uuid == _serviceMotorUuid) {
+        for (final characteristic in service.characteristics) {
+          if (characteristic.uuid == _charMotorToggleUuid) {
+            _secondMotorControlCharacteristic = characteristic;
+            _logBle('胸前 IMU 綁定馬達控制特徵：${characteristic.uuid.str}');
+          }
+        }
+      }
+    }
+
+    final linearCharacteristic = _secondLinearAccelerationCharacteristic;
+    final rotationCharacteristic = _secondGameRotationVectorCharacteristic;
+
+    if (linearCharacteristic == null || rotationCharacteristic == null) {
+      _logBle('胸前 IMU 缺少線性加速度或旋轉特徵，無法啟用感測記錄');
+      if (mounted) {
+        setState(() {
+          _chestConnectionMessage = '裝置未提供完整的感測特徵，請重新配對';
+        });
+      }
+      return;
+    }
+
+    await _initCharacteristic(
+      characteristic: linearCharacteristic,
+      onData: _handleLinearAccelerationPacket,
+      targetSubscriptions: _secondNotificationSubscriptions,
+      onErrorMessage: (message) {
+        if (!mounted) return;
+        setState(() => _chestConnectionMessage = message);
+      },
+    );
+
+    final isListening = await _initCharacteristic(
+      characteristic: rotationCharacteristic,
+      onData: _handleGameRotationVectorPacket,
+      targetSubscriptions: _secondNotificationSubscriptions,
+      onErrorMessage: (message) {
+        if (!mounted) return;
+        setState(() => _chestConnectionMessage = message);
+      },
+    );
+
+    if (!isListening && rotationCharacteristic.properties.read) {
+      _secondGameRotationFallbackTimer = Timer.periodic(
+        const Duration(seconds: 3),
+        (timer) async {
+          if (_isSecondGameRotationFallbackReading) {
+            return;
+          }
+          _isSecondGameRotationFallbackReading = true;
+          try {
+            final value = await rotationCharacteristic.read();
+            if (value.isNotEmpty) {
+              _handleGameRotationVectorPacket(rotationCharacteristic.remoteId.str, value);
+            }
+          } catch (error) {
+            _logBle('胸前 IMU 補償讀取失敗：$error');
+          } finally {
+            _isSecondGameRotationFallbackReading = false;
+          }
+        },
+      );
+      _logBle('胸前 IMU Game Rotation Vector 以補償讀取模式運作');
+    }
+
+    if (mounted) {
+      setState(() {
+        _chestConnectionMessage = '胸前 IMU 感測資料已就緒';
+      });
+    }
+  }
+
+  /// 解析線性加速度封包，並同步寫入 CSV 與更新最新顯示資料
+  void _handleLinearAccelerationPacket(String deviceId, List<int> value) {
+    if (value.length < 16) return;
+    Map<String, dynamic>? sample;
+    for (int offset = 0; offset + 15 < value.length; offset += 16) {
+      final parsed = _parseThreeAxisSample(value, offset);
+      if (parsed == null) continue;
+      sample = parsed;
+      ImuDataLogger.instance.logLinearAcceleration(
+        deviceId,
+        parsed,
+        value.sublist(offset, offset + 16),
+      );
+    }
+    if (sample == null) return;
+    if (!mounted) return;
+    final isPrimary = _isPrimaryDevice(deviceId);
+    final isChest = _isChestDevice(deviceId);
+    if (!isPrimary && !isChest) {
+      return;
+    }
+    setState(() {
+      if (isPrimary) {
+        _latestLinearAcceleration = sample;
+      }
+      if (isChest) {
+        _secondLatestLinearAcceleration = sample;
+      }
+    });
+  }
+
+  /// 解析 Game Rotation Vector 封包並同步紀錄原始資料
+  void _handleGameRotationVectorPacket(String deviceId, List<int> value) {
+    if (value.isEmpty) {
+      return; // 沒有資料時直接結束
+    }
+
+    Map<String, dynamic>? sample;
+    int offset = 0;
+
+    final slotLabel = _isPrimaryDevice(deviceId)
+        ? '右手腕'
+        : (_isChestDevice(deviceId) ? '胸前' : '未知');
+
+    // 逐步解析通知內容，支援 16 bytes（基本欄位）與 20 bytes（額外 accuracy、reserved）封包
+    while (offset < value.length) {
+      final remaining = value.length - offset;
+      final chunkSize = _determineRotationChunkSize(remaining);
+      if (chunkSize == null) {
+        _logBle('Game Rotation Vector 封包長度不足，剩餘 $remaining bytes 無法解析');
+        break;
+      }
+
+      final parsed = _parseRotationSample(value, offset, chunkSize);
+      if (parsed == null) {
+        _logBle('Game Rotation Vector 封包解析失敗，offset=$offset、length=$chunkSize');
+        break;
+      }
+
+      _setLastRotationUpdate(deviceId, DateTime.now());
+
+      final seq = parsed['seq'] as int?;
+      final timestamp = parsed['timestampUs'] as int?;
+      final lastSeq = _getLastRotationSeq(deviceId);
+      final lastTimestamp = _getLastRotationTimestamp(deviceId);
+      final isDuplicate = seq != null &&
+          timestamp != null &&
+          lastSeq == seq &&
+          lastTimestamp == timestamp;
+      if (isDuplicate) {
+        _logBle('[$slotLabel] Game Rotation Vector 收到重複封包：seq=$seq、timestamp=$timestamp，略過寫入與顯示');
+        offset += chunkSize;
+        continue;
+      }
+
+      _setLastRotationSeq(deviceId, seq);
+      _setLastRotationTimestamp(deviceId, timestamp);
+
+      sample = parsed;
+      ImuDataLogger.instance.logGameRotationVector(
+        deviceId,
+        parsed,
+        value.sublist(offset, offset + chunkSize),
+      );
+      offset += chunkSize;
+    }
+
+    if (sample == null || !mounted) {
+      return;
+    }
+
+    _logBle(
+      '[$slotLabel] Game Rotation Vector 更新：seq=${sample['seq']}、i=${_formatNumericLabel(sample['i'] as num?, digits: 4)}、j=${_formatNumericLabel(sample['j'] as num?, digits: 4)}、k=${_formatNumericLabel(sample['k'] as num?, digits: 4)}、w=${_formatNumericLabel(sample['real'] as num?, digits: 4)}',
+    );
+
+    final isPrimary = _isPrimaryDevice(deviceId);
+    final isChest = _isChestDevice(deviceId);
+    if (!isPrimary && !isChest) {
+      return;
+    }
+
+    setState(() {
+      if (isPrimary) {
+        _latestGameRotationVector = sample;
+      }
+      if (isChest) {
+        _secondLatestGameRotationVector = sample;
+      }
+    });
+  }
+
+  /// 啟動 Game Rotation Vector 的補償讀取計時器，避免通知失敗時持續顯示等待
+  void _startGameRotationFallbackTimer({
+    required bool notificationActive,
+    required bool canReadCharacteristic,
+  }) {
+    _cancelGameRotationFallbackTimer();
+    if (_gameRotationVectorCharacteristic == null) {
+      return; // 沒有特徵可讀取時直接離開
+    }
+
+    if (!canReadCharacteristic) {
+      // 裝置僅允許透過通知傳送資料時，留下紀錄並停止補償計時器
+      _logBle('Game Rotation Vector 特徵未提供讀取權限，僅能等待通知資料更新');
+      return;
+    }
+
+    const interval = Duration(seconds: 3);
+    _logBle(
+      '啟動 Game Rotation Vector 補償讀取計時器，通知啟動=$notificationActive、間隔=${interval.inSeconds} 秒',
+    );
+
+    _gameRotationFallbackTimer = Timer.periodic(interval, (timer) async {
+      if (!mounted) {
+        timer.cancel();
+        return;
+      }
+      final characteristic = _gameRotationVectorCharacteristic;
+      if (characteristic == null) {
+        timer.cancel();
+        return;
+      }
+
+      final lastUpdate = _lastGameRotationUpdate;
+      if (lastUpdate != null && DateTime.now().difference(lastUpdate) < interval) {
+        return; // 最近已有資料更新，無需補償讀取
+      }
+
+      if (!characteristic.properties.read) {
+        _logBle('Game Rotation Vector 特徵不支援讀取，無法執行補償流程');
+        timer.cancel();
+        return;
+      }
+
+      if (_isGameRotationFallbackReading) {
+        return; // 上一次補償讀取尚未完成
+      }
+
+      _isGameRotationFallbackReading = true;
+      try {
+        _logBle('Game Rotation Vector 超過 ${interval.inSeconds} 秒未更新，嘗試補償讀取');
+        final value = await characteristic.read();
+        if (value.isNotEmpty) {
+          _handleGameRotationVectorPacket(characteristic.remoteId.str, value);
+        } else {
+          _logBle('Game Rotation Vector 補償讀取回傳空陣列，等待下次機會');
+        }
+      } catch (error, stackTrace) {
+        _logBle('Game Rotation Vector 補償讀取失敗：$error', error: error, stackTrace: stackTrace);
+        // 若裝置明確回報禁止讀取，立即停止補償流程避免持續拋錯
+        if (error is FlutterBluePlusException) {
+          // 某些平台可能不會回傳錯誤字串，因此先進行空值處理後再比對內容
+          final errorMessage = error.errorString ?? '';
+          if (errorMessage.contains('GATT_READ_NOT_PERMITTED')) {
+            _logBle('裝置不允許讀取 Game Rotation Vector，停止補償計時器');
+            timer.cancel();
+          }
+        }
+      } finally {
+        _isGameRotationFallbackReading = false;
+      }
+    });
+  }
+
+  /// 停止 Game Rotation Vector 補償讀取計時器
+  void _cancelGameRotationFallbackTimer() {
+    _gameRotationFallbackTimer?.cancel();
+    _gameRotationFallbackTimer = null;
+    _isGameRotationFallbackReading = false;
+  }
+
+  /// 停止胸前 IMU 的 Game Rotation Vector 補償讀取計時器
+  void _cancelSecondGameRotationFallbackTimer() {
+    _secondGameRotationFallbackTimer?.cancel();
+    _secondGameRotationFallbackTimer = null;
+    _isSecondGameRotationFallbackReading = false;
+  }
+
+  /// 解析三軸感測資料共同欄位（線性加速度、陀螺儀等格式相同）
+  Map<String, dynamic>? _parseThreeAxisSample(List<int> data, int offset) {
+    final timestamp = _readUint32At(data, offset + 4);
+    final rawX = _readInt16At(data, offset + 8);
+    final rawY = _readInt16At(data, offset + 10);
+    final rawZ = _readInt16At(data, offset + 12);
+    if (timestamp == null || rawX == null || rawY == null || rawZ == null) {
+      return null;
+    }
+
+    const double scale = 0.001; // ---------- 依照規格轉換為公尺每秒平方 ----------
+    final double x = rawX * scale;
+    final double y = rawY * scale;
+    final double z = rawZ * scale;
+
+    return {
+      'id': data[offset],
+      'seq': data[offset + 1],
+      'status': data[offset + 2],
+      'timestampUs': timestamp,
+      'x': x,
+      'y': y,
+      'z': z,
+      'rawX': rawX,
+      'rawY': rawY,
+      'rawZ': rawZ,
+    };
+  }
+
+  /// 解析 Game Rotation Vector 專屬的四元數資料結構
+  Map<String, dynamic>? _parseRotationSample(
+    List<int> data,
+    int offset,
+    int length,
+  ) {
+    if (offset + length > data.length) {
+      return null; // 長度超出原始陣列界線時直接忽略
+    }
+
+    final timestamp = _readUint32At(data, offset + 4);
+    final rawI = _readInt16At(data, offset + 8);
+    final rawJ = _readInt16At(data, offset + 10);
+    final rawK = _readInt16At(data, offset + 12);
+    final rawReal = _readInt16At(data, offset + 14);
+    if (timestamp == null || rawI == null || rawJ == null || rawK == null || rawReal == null) {
+      return null;
+    }
+
+    const double qpScaling = 1.0 / 16384.0; // ---------- Q14 固定小數點轉浮點 ----------
+    final double i = rawI * qpScaling;
+    final double j = rawJ * qpScaling;
+    final double k = rawK * qpScaling;
+    final double real = rawReal * qpScaling;
+
+    // accuracy 與 reserved 僅存在於較新的韌體（20 bytes 封包），舊版則保持 null
+    int? accuracy;
+    int? reserved;
+    if (length >= 18) {
+      accuracy = _readInt16At(data, offset + 16);
+    }
+    if (length >= 20) {
+      reserved = _readInt16At(data, offset + 18);
+    }
+
+    return {
+      'id': data[offset],
+      'seq': data[offset + 1],
+      'status': data[offset + 2],
+      'timestampUs': timestamp,
+      'i': i,
+      'j': j,
+      'k': k,
+      'real': real,
+      'w': real,
+      'rawI': rawI,
+      'rawJ': rawJ,
+      'rawK': rawK,
+      'rawReal': rawReal,
+      'accuracy': accuracy,
+      'reserved': reserved,
+      'packetLength': length,
+    };
+  }
+
+  /// 判斷 Game Rotation Vector 封包長度，根據剩餘位元組推算應使用的解析長度
+  int? _determineRotationChunkSize(int remaining) {
+    if (remaining >= 20 && remaining % 20 == 0 && remaining % 16 != 0) {
+      return 20; // 偏好整除 20 的情境，代表每筆資料都附帶 accuracy/reserved
+    }
+    if (remaining >= 16 && remaining % 16 == 0) {
+      return 16; // 整除 16 代表舊版韌體僅有基本欄位
+    }
+    if (remaining >= 20) {
+      return 20; // 儘管無法整除，也優先嘗試較大的封包以保留額外欄位
+    }
+    if (remaining >= 16) {
+      return 16; // 最小需求 16 bytes（含四元數基本欄位）
+    }
+    return null;
+  }
+
+  /// 解析按鈕通知封包，轉換為可讀描述供 UI 顯示
+  void _handleButtonPacket(List<int> value) {
+    if (value.isEmpty) return;
+    final raw = value.first;
+    final clickTimes = (raw >> 4) & 0x0F;
+    final eventCode = raw & 0x0F;
+    final description = _describeButtonEvent(eventCode);
+    _logBle('接收到按鈕事件：code=$eventCode、click=$clickTimes、raw=${value.first}');
+    if (!mounted) return;
+    setState(() {
+      _buttonClickTimes = clickTimes;
+      _buttonEventCode = eventCode;
+      _lastButtonEventTime = DateTime.now();
+      if (clickTimes > 1) {
+        _buttonStatusText = '$description · 連擊 $clickTimes 次';
+      } else {
+        _buttonStatusText = description;
+      }
+    });
+
+    // ---------- 以右手腕短按啟動錄影 ----------
+    if (!mounted) {
+      return;
+    }
+
+    // ---------- 針對短按開始或結束觸發錄影 ----------
+    final bool isShortPressEvent = eventCode == 0x01 || eventCode == 0x02;
+    if (isShortPressEvent && clickTimes <= 1) {
+      final now = DateTime.now();
+      final shouldTrigger = _lastButtonTriggerTime == null ||
+          now.difference(_lastButtonTriggerTime!).inMilliseconds > 800;
+      if (!shouldTrigger) {
+        _logBle('按鈕事件與前次觸發過於接近，避免重複開啟錄影');
+        return;
+      }
+      _lastButtonTriggerTime = now; // 記錄此次觸發時間，避免短時間內重複響應
+
+      if (_isSessionPageVisible) {
+        // 若錄影頁面已開啟，直接轉交事件給錄影頁啟動倒數
+        _logBle('錄影頁面已開啟，轉交硬體按鈕觸發倒數錄影');
+        _imuButtonController.add(null);
+        return;
+      }
+      if (_isOpeningSession) {
+        _logBle('按鈕觸發錄影但畫面尚在開啟中，略過重複事件');
+        return;
+      }
+      _logBle('偵測到短按事件（code=$eventCode），準備自動開啟錄影畫面並預約自動倒數');
+      // 透過硬體按鈕觸發時，直接沿用使用者目前的錄影次數／秒數設定，避免再跳出彈窗
+      unawaited(_openRecordingSession(triggeredByImuButton: true));
+    }
+  }
+
+  /// 將按鈕事件代碼轉成中文說明
+  String _describeButtonEvent(int code) {
+    switch (code) {
+      case 0x01:
+        return '短按開始';
+      case 0x02:
+        return '短按結束';
+      case 0x03:
+        return '長按開始';
+      case 0x04:
+        return '長按保持';
+      case 0x05:
+        return '長按結束';
+      default:
+        return '未知事件 (0x${code.toRadixString(16)})';
+    }
+  }
+
+  /// 將單位為百分比的電量更新至狀態
+  void _updateBatteryLevel(List<int> value) {
+    if (value.isEmpty) return;
+    final int level = value.first.clamp(0, 100).toInt();
+    if (!mounted) return;
+    setState(() {
+      _batteryLevelText = '$level%';
+    });
+  }
+
+  /// 解析毫伏資料
+  void _updateBatteryVoltage(List<int> value) {
+    final voltage = _readUint32At(value, 0);
+    if (voltage == null || !mounted) return;
+    setState(() {
+      _batteryVoltageText = '${(voltage / 1000.0).toStringAsFixed(2)} V';
+    });
+  }
+
+  /// 解析充電電流（mA）
+  void _updateBatteryChargeCurrent(List<int> value) {
+    final current = _readUint32At(value, 0);
+    if (current == null || !mounted) return;
+    setState(() {
+      _batteryChargeCurrentText = '$current mA';
+    });
+  }
+
+  /// 解析電池溫度（攝氏）
+  void _updateBatteryTemperature(List<int> value) {
+    final temperature = _readUint32At(value, 0);
+    if (temperature == null || !mounted) return;
+    setState(() {
+      _batteryTemperatureText = '${(temperature / 100.0).toStringAsFixed(1)} °C';
+    });
+  }
+
+  /// 解析剩餘電量（mAh）
+  void _updateBatteryRemaining(List<int> value) {
+    final remaining = _readUint32At(value, 0);
+    if (remaining == null || !mounted) return;
+    setState(() {
+      _batteryRemainingText = '$remaining mAh';
+    });
+  }
+
+  /// 解析剩餘使用時間（分鐘）
+  void _updateBatteryTimeToEmpty(List<int> value) {
+    final minutes = _readUint32At(value, 0);
+    if (minutes == null || !mounted) return;
+    setState(() {
+      _batteryTimeToEmptyText = _formatMinutes(minutes);
+    });
+  }
+
+  /// 解析充滿所需時間（分鐘）
+  void _updateBatteryTimeToFull(List<int> value) {
+    final minutes = _readUint32At(value, 0);
+    if (minutes == null || !mounted) return;
+    setState(() {
+      _batteryTimeToFullText = _formatMinutes(minutes);
+    });
+  }
+
+  /// 嘗試讀取 32bit 無號整數（小端序），若資料長度不足則回傳 null
+  int? _readUint32At(List<int> data, int offset) {
+    if (offset + 3 >= data.length) return null;
+    return data[offset] |
+        (data[offset + 1] << 8) |
+        (data[offset + 2] << 16) |
+        (data[offset + 3] << 24);
+  }
+
+  /// 嘗試讀取 16bit 有號整數（小端序），若資料長度不足則回傳 null
+  int? _readInt16At(List<int> data, int offset) {
+    if (offset + 1 >= data.length) return null;
+    final value = data[offset] | (data[offset + 1] << 8);
+    return value >= 0x8000 ? value - 0x10000 : value;
+  }
+
+  /// 將分鐘轉為可讀格式
+  String _formatMinutes(int minutes) {
+    final hours = minutes ~/ 60;
+    final remainMinutes = minutes % 60;
+    if (hours == 0) {
+      return '$remainMinutes 分鐘';
+    }
+    return '${hours} 小時 ${remainMinutes} 分';
+  }
+
+  /// 讀取 UTF-8 編碼字串並清除尾端的 0x00
+  Future<void> _readAndAssignString(
+    BluetoothCharacteristic? characteristic,
+    void Function(String value) assign,
+  ) async {
+    if (characteristic == null || !characteristic.properties.read) {
+      _logBle('跳過讀取字串：特徵不存在或不可讀 ${characteristic?.uuid.str ?? 'null'}');
+      return;
+    }
+    try {
+      final value = await characteristic.read();
+      final text = _decodeUtf8String(value);
+      if (!mounted) return;
+      setState(() {
+        assign(text);
+      });
+      _logBle('成功讀取字串特徵：${characteristic.uuid.str}，內容：$text');
+    } catch (error, stackTrace) {
+      // 裝置若暫時無法讀取字串則忽略錯誤
+      _logBle('讀取字串特徵失敗：${characteristic.uuid.str}，原因：$error', error: error, stackTrace: stackTrace);
+    }
+  }
+
+  /// 將 byte array 轉為可讀字串，並移除尾端補零
+  String _decodeUtf8String(List<int> data) {
+    final trimmed = data.takeWhile((value) => value != 0).toList();
+    if (trimmed.isEmpty) {
+      return '';
+    }
+    return utf8.decode(trimmed, allowMalformed: true);
+  }
+
+  /// 依插槽觸發短暫震動，方便使用者確認手上設備的位置
+  Future<void> _triggerMotorPulseForSlot(_ImuSlotType slot) async {
+    final characteristic = _motorCharacteristicForSlot(slot);
+    if (characteristic == null) {
+      if (!mounted) {
+        return;
+      }
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(content: Text('${slot.displayLabel} 尚未取得震動控制特徵，請確認裝置已連線。')),
+      );
+      return;
+    }
+
+    if (_isMotorBusyForSlot(slot)) {
+      _logBle('${slot.displayLabel} 震動命令仍在執行中，略過重複請求');
+      return;
+    }
+    _setMotorBusyForSlot(slot, true);
+
+    final bool supportsWriteWithResponse = characteristic.properties.write;
+    final bool supportsWriteWithoutResponse = characteristic.properties.writeWithoutResponse;
+    final bool useWithoutResponse = !supportsWriteWithResponse && supportsWriteWithoutResponse;
+
+    try {
+      await _bleOperationQueue.enqueue(() async {
+        await characteristic.write([1], withoutResponse: useWithoutResponse);
+        await Future.delayed(const Duration(milliseconds: 500));
+        await characteristic.write([0], withoutResponse: useWithoutResponse);
+      }, spacing: const Duration(milliseconds: 320));
+    } catch (error, stackTrace) {
+      _logBle('震動命令失敗：${characteristic.uuid.str}，原因：$error',
+          error: error, stackTrace: stackTrace);
+      if (mounted) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(content: Text('${slot.displayLabel} 震動失敗：$error')),
+        );
+      }
+    } finally {
+      _setMotorBusyForSlot(slot, false);
+    }
+  }
+
+  /// 判斷目前是否已建立右手腕 IMU 連線
+  bool get isPrimaryImuConnected =>
+      _connectedDevice != null && _connectionState == BluetoothConnectionState.connected;
+
+  /// 判斷目前是否已建立胸前 IMU 連線
+  bool get isChestImuConnected =>
+      _secondDevice != null && _secondConnectionState == BluetoothConnectionState.connected;
+
+  /// 只要任一 IMU 已連線即視為可搭配錄影
+  bool get isImuConnected => isPrimaryImuConnected || isChestImuConnected;
+
+  /// 檢查給定裝置識別碼是否對應右手腕 IMU
+  bool _isPrimaryDevice(String deviceId) =>
+      _connectedDevice != null && _connectedDevice!.remoteId.str == deviceId;
+
+  /// 檢查給定裝置識別碼是否對應胸前 IMU
+  bool _isChestDevice(String deviceId) =>
+      _secondDevice != null && _secondDevice!.remoteId.str == deviceId;
+
+  DateTime? _getLastRotationUpdate(String deviceId) =>
+      _isPrimaryDevice(deviceId) ? _lastGameRotationUpdate : (_isChestDevice(deviceId) ? _secondLastGameRotationUpdate : null);
+
+  void _setLastRotationUpdate(String deviceId, DateTime? value) {
+    if (_isPrimaryDevice(deviceId)) {
+      _lastGameRotationUpdate = value;
+    } else if (_isChestDevice(deviceId)) {
+      _secondLastGameRotationUpdate = value;
+    }
+  }
+
+  int? _getLastRotationSeq(String deviceId) =>
+      _isPrimaryDevice(deviceId) ? _lastGameRotationSeq : (_isChestDevice(deviceId) ? _secondLastGameRotationSeq : null);
+
+  void _setLastRotationSeq(String deviceId, int? value) {
+    if (_isPrimaryDevice(deviceId)) {
+      _lastGameRotationSeq = value;
+    } else if (_isChestDevice(deviceId)) {
+      _secondLastGameRotationSeq = value;
+    }
+  }
+
+  int? _getLastRotationTimestamp(String deviceId) => _isPrimaryDevice(deviceId)
+      ? _lastGameRotationTimestamp
+      : (_isChestDevice(deviceId) ? _secondLastGameRotationTimestamp : null);
+
+  void _setLastRotationTimestamp(String deviceId, int? value) {
+    if (_isPrimaryDevice(deviceId)) {
+      _lastGameRotationTimestamp = value;
+    } else if (_isChestDevice(deviceId)) {
+      _secondLastGameRotationTimestamp = value;
+    }
+  }
+
+  /// 根據裝置資訊推算顯示名稱
+  String _resolveDeviceName(BluetoothDevice device) {
+    if (device.platformName.isNotEmpty) {
+      return device.platformName;
+    }
+    return device.remoteId.str;
+  }
+
+  /// 判斷服務列表是否包含 TekSwing IMU 相關 UUID
+  bool _containsImuService(List<BluetoothService> services) {
+    for (final service in services) {
+      if (service.uuid == _serviceBno086Uuid || service.uuid == _nordicUartServiceUuid) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  /// 根據廣播資料判斷是否為 IMU 裝置
+  bool _isImuAdvertisement(AdvertisementData data) {
+    // 以服務 UUID 為主進行比對，避免依賴容易變動的名稱
+    final serviceUuids = data.serviceUuids;
+    if (serviceUuids.contains(_serviceBno086Uuid) || serviceUuids.contains(_nordicUartServiceUuid)) {
+      return true;
+    }
+
+    // 若廣播未列出 serviceUuids，改從 serviceData key 再檢查一次
+    final serviceDataKeys = data.serviceData.keys;
+    for (final key in serviceDataKeys) {
+      if (key == _serviceBno086Uuid || key == _nordicUartServiceUuid) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  /// 切換至錄影專用頁面，讓錄影與配對流程分離
+  Future<void> _openRecordingSession({bool triggeredByImuButton = false}) async {
+    if (_isOpeningSession) return; // 避免重複點擊快速開啟多個頁面
+
+    if (widget.cameras.isEmpty) {
+      if (!mounted) return;
+      ScaffoldMessenger.of(context).showSnackBar(
+        const SnackBar(content: Text('沒有可用鏡頭，無法開始錄影。')),
+      );
+      return;
+    }
+
+    setState(() => _isOpeningSession = true);
+
+    Map<String, int>? config;
+    if (triggeredByImuButton) {
+      // ---------- 硬體按鈕自動啟動 ----------
+      // 直接沿用目前頁面記錄的設定值，避免在揮桿時還要操作彈窗
+      config = {
+        'rounds': _selectedRounds,
+        'seconds': _recordingDurationSeconds,
+      };
+    } else {
+      // ---------- 手動點擊按鈕 ----------
+      // 進入錄影前先彈出設定視窗，讓使用者選擇要錄影的次數與長度
+      config = await _showRecordingConfigDialog();
+      if (config == null) {
+        if (!mounted) return;
+        setState(() => _isOpeningSession = false);
+        return; // 使用者取消設定則不進入錄影畫面
+      }
+
+      setState(() {
+        _selectedRounds = config!['rounds']!;
+        _recordingDurationSeconds = config['seconds']!;
+      });
+    }
+
+    config ??= {
+      'rounds': _selectedRounds,
+      'seconds': _recordingDurationSeconds,
+    };
+    final int rounds = config['rounds'] ?? _selectedRounds;
+    final int seconds = config['seconds'] ?? _recordingDurationSeconds;
+
+    List<RecordingHistoryEntry>? historyFromSession;
+    _isSessionPageVisible = true; // 標記錄影頁面已開啟，後續按鈕事件直接轉交
+    try {
+      historyFromSession = await Navigator.push<List<RecordingHistoryEntry>>(
+        context,
+        MaterialPageRoute(
+          builder: (_) => RecordingSessionPage(
+            cameras: widget.cameras,
+            isImuConnected: isImuConnected,
+            totalRounds: rounds,
+            durationSeconds: seconds,
+            autoStartOnReady: triggeredByImuButton,
+            imuButtonStream: _imuButtonController.stream,
+          ),
+        ),
+      );
+    } finally {
+      _isSessionPageVisible = false; // 不論結果如何都重設狀態
+    }
+    if (!mounted) return;
+    if (historyFromSession != null && historyFromSession.isNotEmpty) {
+      // 轉為不可變清單，確保 setState 閉包中使用時不會被外部修改
+      final List<RecordingHistoryEntry> sessionEntries =
+          List<RecordingHistoryEntry>.unmodifiable(historyFromSession);
+      setState(() {
+        final existingPaths = _recordingHistory.map((e) => e.filePath).toSet();
+        for (final entry in sessionEntries) {
+          if (!existingPaths.contains(entry.filePath)) {
+            _recordingHistory.insert(0, entry);
+          }
+        }
+      });
+      widget.onHistoryChanged(
+        List<RecordingHistoryEntry>.from(_recordingHistory),
+      ); // 即時回傳最新清單給首頁同步顯示
+      unawaited(
+        RecordingHistoryStorage.instance.saveHistory(_recordingHistory),
+      ); // 將結果寫入檔案，避免重啟後遺失
+    }
+    setState(() => _isOpeningSession = false);
+  }
+
+  /// 顯示設定錄影次數與秒數的彈窗，確保使用者可以自訂錄影需求
+  Future<Map<String, int>?> _showRecordingConfigDialog() async {
+    int rounds = _selectedRounds;
+    int seconds = _recordingDurationSeconds;
+
+    return showDialog<Map<String, int>>(
+      context: context,
+      builder: (context) {
+        return StatefulBuilder(
+          builder: (context, setModalState) {
+            return AlertDialog(
+              title: const Text('設定錄影參數'),
+              content: Column(
+                mainAxisSize: MainAxisSize.min,
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  const Text(
+                    '請選擇本次錄影的輪數與每輪秒數，稍後錄影畫面將依據設定自動執行。',
+                    style: TextStyle(fontSize: 13, height: 1.4),
+                  ),
+                  const SizedBox(height: 16),
+                  _buildConfigSlider(
+                    label: '錄影次數',
+                    description: '可自訂本次要錄影的輪數，建議依自身練習需求調整。',
+                    value: rounds.toDouble(),
+                    min: 1,
+                    max: 12,
+                    division: 11,
+                    unit: '次',
+                    onChanged: (value) {
+                      // 透過 round() 與上下界控制確保數值落在合法範圍
+                      setModalState(() {
+                        rounds = value.round();
+                        if (rounds < 1) rounds = 1;
+                        if (rounds > 12) rounds = 12;
+                      });
+                    },
+                    onInputChanged: (value) {
+                      final parsed = int.tryParse(value);
+                      if (parsed != null) {
+                        setModalState(() {
+                          rounds = parsed;
+                          if (rounds < 1) rounds = 1;
+                          if (rounds > 12) rounds = 12;
+                        });
+                      }
+                    },
+                  ),
+                  const SizedBox(height: 16),
+                  _buildConfigSlider(
+                    label: '每次長度',
+                    description: '調整每輪錄影秒數，支援 3 至 60 秒細緻設定。',
+                    value: seconds.toDouble(),
+                    min: 3,
+                    max: 60,
+                    division: 57,
+                    unit: '秒',
+                    onChanged: (value) {
+                      setModalState(() {
+                        seconds = value.round();
+                        if (seconds < 3) seconds = 3;
+                        if (seconds > 60) seconds = 60;
+                      });
+                    },
+                    onInputChanged: (value) {
+                      final parsed = int.tryParse(value);
+                      if (parsed != null) {
+                        setModalState(() {
+                          seconds = parsed;
+                          if (seconds < 3) seconds = 3;
+                          if (seconds > 60) seconds = 60;
+                        });
+                      }
+                    },
+                  ),
+                ],
+              ),
+              actions: [
+                TextButton(
+                  onPressed: () => Navigator.pop(context),
+                  child: const Text('取消'),
+                ),
+                FilledButton(
+                  onPressed: () => Navigator.pop(context, {'rounds': rounds, 'seconds': seconds}),
+                  child: const Text('確定開始'),
+                ),
+              ],
+            );
+          },
+        );
+      },
+    );
+  }
+
+  /// 建構設定錄影參數的滑桿與輸入欄位，提供使用者細緻調整能力
+  Widget _buildConfigSlider({
+    required String label,
+    required String description,
+    required double value,
+    required double min,
+    required double max,
+    required int division,
+    required String unit,
+    required ValueChanged<double> onChanged,
+    required ValueChanged<String> onInputChanged,
+  }) {
+    final controller = TextEditingController(text: value.round().toString());
+
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Text(
+          label,
+          style: const TextStyle(fontSize: 14, fontWeight: FontWeight.w600),
+        ),
+        const SizedBox(height: 4),
+        Text(
+          description,
+          style: const TextStyle(fontSize: 12, color: Color(0xFF6F7B86)),
+        ),
+        Slider(
+          value: value.clamp(min, max),
+          min: min,
+          max: max,
+          divisions: division,
+          label: '${value.round()} $unit',
+          onChanged: onChanged,
+        ),
+        Row(
+          children: [
+            // 透過 IconButton 提供快速微調
+            IconButton(
+              icon: const Icon(Icons.remove_circle_outline),
+              onPressed: () {
+                final nextValue = (value - 1).clamp(min, max);
+                onChanged(nextValue);
+              },
+            ),
+            SizedBox(
+              width: 72,
+              child: TextField(
+                controller: controller,
+                keyboardType: TextInputType.number,
+                textAlign: TextAlign.center,
+                decoration: InputDecoration(
+                  isDense: true,
+                  contentPadding: const EdgeInsets.symmetric(vertical: 8),
+                  suffixText: unit,
+                  border: OutlineInputBorder(
+                    borderRadius: BorderRadius.circular(8),
+                  ),
+                ),
+                onChanged: onInputChanged,
+              ),
+            ),
+            IconButton(
+              icon: const Icon(Icons.add_circle_outline),
+              onPressed: () {
+                final nextValue = (value + 1).clamp(min, max);
+                onChanged(nextValue);
+              },
+            ),
+            const Spacer(),
+            Text(
+              '範圍 ${min.round()}~${max.round()} $unit',
+              style: const TextStyle(fontSize: 11, color: Color(0xFF9AA6B2)),
+            ),
+          ],
+        ),
+      ],
+    );
+  }
+
+  /// 共用的資訊列樣式，左側顯示圖示右側呈現標題與描述
+  Widget _buildInfoRow(
+    IconData icon,
+    String title,
+    String value, {
+    String? subtitle,
+  }) {
+    return Row(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Icon(icon, size: 20, color: const Color(0xFF123B70)),
+        const SizedBox(width: 12),
+        Expanded(
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Text(
+                title,
+                style: const TextStyle(
+                  fontSize: 14,
+                  fontWeight: FontWeight.w600,
+                  color: Color(0xFF1E1E1E),
+                ),
+              ),
+              const SizedBox(height: 2),
+              Text(
+                value,
+                style: const TextStyle(fontSize: 13, color: Color(0xFF465A71), height: 1.3),
+              ),
+              if (subtitle != null) ...[
+                const SizedBox(height: 2),
+                Text(
+                  subtitle,
+                  style: const TextStyle(fontSize: 12, color: Color(0xFF9AA8B6)),
+                ),
+              ],
+            ],
+          ),
+        ),
+      ],
+    );
+  }
+
+  /// 感測資料區塊，整合兩顆 IMU 的最新狀態
+  Widget _buildSensorDataSection() {
+    final List<Widget> groups = [];
+
+    // ---------- 右手腕 IMU ----------
+    final List<String> buttonDetails = [];
+    if (_buttonClickTimes != null && _buttonClickTimes! > 0) {
+      buttonDetails.add('連擊 ${_buttonClickTimes!} 次');
+    }
+    if (_buttonEventCode != null) {
+      buttonDetails.add('代碼 0x${_buttonEventCode!.toRadixString(16).padLeft(2, '0')}');
+    }
+    if (_lastButtonEventTime != null) {
+      buttonDetails.add('最近 ${_formatTimeOfDay(_lastButtonEventTime!)}');
+    }
+    final String primaryTitle = _connectedDevice != null
+        ? _resolveDeviceName(_connectedDevice!)
+        : '右手腕 IMU';
+    groups.add(
+      _buildSensorDataGroup(
+        title: primaryTitle,
+        headerIcon: Icons.sports_golf,
+        buttonStatus: _buttonStatusText,
+        buttonSubtitle: buttonDetails.isEmpty ? null : buttonDetails.join(' · '),
+        linearSummary: _formatLinearAccelerationSummary(_latestLinearAcceleration),
+        linearMeta: _formatThreeAxisMeta(_latestLinearAcceleration),
+        rotationSummary: _formatRotationSummary(_latestGameRotationVector),
+        rotationMeta: _formatRotationMeta(_latestGameRotationVector),
+      ),
+    );
+
+    // ---------- 胸前 IMU ----------
+    final bool hasChestData =
+        _secondLatestLinearAcceleration != null || _secondLatestGameRotationVector != null || isChestImuConnected;
+    if (hasChestData) {
+      final String chestTitle =
+          _secondDevice != null ? _resolveDeviceName(_secondDevice!) : '胸前 IMU';
+      groups.add(const SizedBox(height: 14));
+      groups.add(
+        _buildSensorDataGroup(
+          title: chestTitle,
+          headerIcon: Icons.accessibility_new,
+          buttonStatus: null,
+          buttonSubtitle: null,
+          linearSummary: _formatLinearAccelerationSummary(_secondLatestLinearAcceleration),
+          linearMeta: _formatThreeAxisMeta(_secondLatestLinearAcceleration),
+          rotationSummary: _formatRotationSummary(_secondLatestGameRotationVector),
+          rotationMeta: _formatRotationMeta(_secondLatestGameRotationVector),
+        ),
+      );
+    }
+
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        const Text(
+          '感測資料',
+          style: TextStyle(
+            fontSize: 15,
+            fontWeight: FontWeight.w700,
+            color: Color(0xFF123B70),
+          ),
+        ),
+        const SizedBox(height: 8),
+        ...groups,
+      ],
+    );
+  }
+
+  /// 個別 IMU 的感測摘要卡片，統一顯示按鈕、加速度與旋轉資訊
+  Widget _buildSensorDataGroup({
+    required String title,
+    required IconData headerIcon,
+    required String linearSummary,
+    required String rotationSummary,
+    String? linearMeta,
+    String? rotationMeta,
+    String? buttonStatus,
+    String? buttonSubtitle,
+  }) {
+    return Container(
+      width: double.infinity,
+      padding: const EdgeInsets.all(16),
+      decoration: BoxDecoration(
+        color: const Color(0xFFF4F8FB),
+        borderRadius: BorderRadius.circular(16),
+        border: Border.all(color: const Color(0xFFE1E8F0)),
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Row(
+            children: [
+              Icon(headerIcon, color: const Color(0xFF123B70)),
+              const SizedBox(width: 8),
+              Text(
+                title,
+                style: const TextStyle(
+                  fontSize: 14,
+                  fontWeight: FontWeight.w700,
+                  color: Color(0xFF123B70),
+                ),
+              ),
+            ],
+          ),
+          const SizedBox(height: 10),
+          if (buttonStatus != null) ...[
+            _buildInfoRow(Icons.smart_button, '按鈕事件', buttonStatus, subtitle: buttonSubtitle),
+            const SizedBox(height: 10),
+          ],
+          _buildInfoRow(Icons.trending_up, '線性加速度', linearSummary, subtitle: linearMeta),
+          const SizedBox(height: 10),
+          _buildInfoRow(
+            Icons.threed_rotation,
+            'Game Rotation Vector',
+            rotationSummary,
+            subtitle: rotationMeta,
+          ),
+        ],
+      ),
+    );
+  }
+
+  /// 電池與充電狀態資訊
+  Widget _buildBatterySection() {
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        const Text(
+          '電池資訊',
+          style: TextStyle(
+            fontSize: 15,
+            fontWeight: FontWeight.w700,
+            color: Color(0xFF123B70),
+          ),
+        ),
+        const SizedBox(height: 8),
+        _buildInfoRow(Icons.battery_full, '電量', _batteryLevelText ?? '等待裝置回報'),
+        const SizedBox(height: 10),
+        _buildInfoRow(Icons.bolt, '電壓', _batteryVoltageText ?? '--'),
+        const SizedBox(height: 10),
+        _buildInfoRow(Icons.flash_on, '充電電流', _batteryChargeCurrentText ?? '--'),
+        const SizedBox(height: 10),
+        _buildInfoRow(Icons.thermostat, '電池溫度', _batteryTemperatureText ?? '--'),
+        const SizedBox(height: 10),
+        _buildInfoRow(Icons.storage, '剩餘電量', _batteryRemainingText ?? '--'),
+        const SizedBox(height: 10),
+        _buildInfoRow(Icons.timer, '使用時間預估', _batteryTimeToEmptyText ?? '--'),
+        const SizedBox(height: 10),
+        _buildInfoRow(Icons.hourglass_bottom, '充滿所需時間', _batteryTimeToFullText ?? '--'),
+      ],
+    );
+  }
+
+  /// 裝置資訊區塊，顯示韌體與硬體等資料
+  Widget _buildDeviceInfoSection() {
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        const Text(
+          '裝置資訊',
+          style: TextStyle(
+            fontSize: 15,
+            fontWeight: FontWeight.w700,
+            color: Color(0xFF123B70),
+          ),
+        ),
+        const SizedBox(height: 8),
+        _buildInfoRow(Icons.badge, '自訂名稱', _customDeviceName?.isNotEmpty == true ? _customDeviceName! : '--'),
+        const SizedBox(height: 10),
+        _buildInfoRow(Icons.device_hub, '裝置型號', _deviceModelName?.isNotEmpty == true ? _deviceModelName! : '--'),
+        const SizedBox(height: 10),
+        _buildInfoRow(Icons.confirmation_number, '序號', _deviceSerialNumber?.isNotEmpty == true ? _deviceSerialNumber! : '--'),
+        const SizedBox(height: 10),
+        _buildInfoRow(Icons.system_update, '韌體版本', _firmwareRevision?.isNotEmpty == true ? _firmwareRevision! : '--'),
+        const SizedBox(height: 10),
+        _buildInfoRow(Icons.memory, '硬體版本', _hardwareRevision?.isNotEmpty == true ? _hardwareRevision! : '--'),
+        const SizedBox(height: 10),
+        _buildInfoRow(Icons.code, '軟體版本', _softwareRevision?.isNotEmpty == true ? _softwareRevision! : '--'),
+        const SizedBox(height: 10),
+        _buildInfoRow(Icons.factory, '製造商', _manufacturerName?.isNotEmpty == true ? _manufacturerName! : '--'),
+      ],
+    );
+  }
+
+  /// 震動馬達測試按鈕，協助確認馬達控制是否可用
+  Widget _buildMotorControlSection() {
+    final bool primaryAvailable = _motorControlCharacteristic != null;
+    final bool chestAvailable = _secondMotorControlCharacteristic != null;
+
+    if (!primaryAvailable && !chestAvailable) {
+      return Row(
+        children: const [
+          Icon(Icons.vibration, color: Color(0xFF123B70)),
+          SizedBox(width: 12),
+          Expanded(
+            child: Text(
+              '尚未取得震動控制特徵，可重新連線後再嘗試震動識別。',
+              style: TextStyle(fontSize: 13, color: Color(0xFF465A71)),
+            ),
+          ),
+        ],
+      );
+    }
+
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        const Row(
+          children: [
+            Icon(Icons.vibration, color: Color(0xFF123B70)),
+            SizedBox(width: 8),
+            Text(
+              '震動測試',
+              style: TextStyle(
+                fontSize: 15,
+                fontWeight: FontWeight.w700,
+                color: Color(0xFF123B70),
+              ),
+            ),
+          ],
+        ),
+        const SizedBox(height: 8),
+        const Text(
+          '點擊下方按鈕可讓指定 IMU 短暫震動，協助辨識目前手持的裝置。',
+          style: TextStyle(fontSize: 13, color: Color(0xFF465A71)),
+        ),
+        const SizedBox(height: 12),
+        Wrap(
+          spacing: 12,
+          runSpacing: 12,
+          children: [
+            if (primaryAvailable) _buildMotorTestButton(_ImuSlotType.rightWrist),
+            if (chestAvailable) _buildMotorTestButton(_ImuSlotType.chest),
+          ],
+        ),
+      ],
+    );
+  }
+
+  /// 個別插槽專屬的震動按鈕
+  Widget _buildMotorTestButton(_ImuSlotType slot) {
+    final bool busy = _isMotorBusyForSlot(slot);
+    final String label = slot == _ImuSlotType.rightWrist ? '右手腕震動' : '胸前震動';
+    return FilledButton.tonalIcon(
+      onPressed: busy ? null : () => _triggerMotorPulseForSlot(slot),
+      icon: const Icon(Icons.vibration),
+      label: busy
+          ? const SizedBox(
+              width: 18,
+              height: 18,
+              child: CircularProgressIndicator(strokeWidth: 2),
+            )
+          : Text(label),
+    );
+  }
+
+  /// 將線性加速度資料轉成可讀摘要
+  String _formatLinearAccelerationSummary(Map<String, dynamic>? sample) {
+    if (sample == null) {
+      return '等待裝置傳送資料';
+    }
+    final x = sample['x'] as num?;
+    final y = sample['y'] as num?;
+    final z = sample['z'] as num?;
+    return 'X: ${_formatNumericLabel(x)} · Y: ${_formatNumericLabel(y)} · Z: ${_formatNumericLabel(z)} (g)';
+  }
+
+  /// 顯示線性加速度額外資訊（序號、狀態、時間）
+  String? _formatThreeAxisMeta(Map<String, dynamic>? sample) {
+    if (sample == null) {
+      return null;
+    }
+    final seq = sample['seq'];
+    final status = sample['status'];
+    final timestamp = sample['timestampUs'];
+    return '序號 $seq · 狀態 $status · 時間標籤 ${timestamp ?? '--'} μs';
+  }
+
+  /// 將四元數資訊轉成摘要文字
+  String _formatRotationSummary(Map<String, dynamic>? sample) {
+    if (sample == null) {
+      return '等待裝置傳送資料';
+    }
+    final i = sample['i'] as num?;
+    final j = sample['j'] as num?;
+    final k = sample['k'] as num?;
+    final real = sample['real'] as num?;
+    return 'i: ${_formatNumericLabel(i, digits: 4)} · j: ${_formatNumericLabel(j, digits: 4)} · k: ${_formatNumericLabel(k, digits: 4)} · w: ${_formatNumericLabel(real, digits: 4)}';
+  }
+
+  /// 顯示四元數額外資訊
+  String? _formatRotationMeta(Map<String, dynamic>? sample) {
+    if (sample == null) {
+      return null;
+    }
+    final seq = sample['seq'];
+    final status = sample['status'];
+    final timestamp = sample['timestampUs'];
+    final accuracy = sample['accuracy'];
+    final packetLength = sample['packetLength'];
+    final buffer = <String>[
+      '序號 $seq',
+      '狀態 $status',
+      '時間標籤 ${timestamp ?? '--'} μs',
+    ];
+    if (accuracy != null) {
+      buffer.add('準確度 $accuracy');
+    }
+    if (packetLength != null) {
+      buffer.add('封包 ${packetLength} bytes');
+    }
+    return buffer.join(' · ');
+  }
+
+  /// 將數值統一格式化，避免 UI 出現過長的小數或 null 字樣
+  String _formatNumericLabel(num? value, {int digits = 3}) {
+    if (value == null) {
+      return '--';
+    }
+    return value.toStringAsFixed(digits);
+  }
+
+  /// 將時間格式化為 HH:mm:ss 字串
+  String _formatTimeOfDay(DateTime time) {
+    final local = time.toLocal();
+    String twoDigits(int value) => value.toString().padLeft(2, '0');
+    return '${twoDigits(local.hour)}:${twoDigits(local.minute)}:${twoDigits(local.second)}';
+  }
+
+  /// 建構 IMU 連線卡片，提示使用者完成藍牙配對
+  Widget _buildImuConnectionCard() {
+    final bool primaryConnected = isPrimaryImuConnected;
+    final bool hasCandidate = _foundDevice != null;
+    final String primaryTitle = primaryConnected
+        ? _resolveDeviceName(_connectedDevice!)
+        : (_foundDeviceName ?? '右手腕 IMU');
+    final String primarySignal =
+        _lastRssi != null ? '訊號 ${_lastRssi} dBm' : '訊號偵測中';
+    final String batteryOverview = _batteryLevelText ?? '電量讀取中';
+    final String firmwareOverview =
+        (_firmwareRevision?.isNotEmpty == true) ? _firmwareRevision! : '韌體資訊更新中';
+
+    final bool chestConnected = isChestImuConnected;
+    final String chestTitle = chestConnected
+        ? _resolveDeviceName(_secondDevice!)
+        : '胸前 IMU';
+    final String chestDetail = chestConnected ? '資料串流中' : '等待綁定';
+    final bool anyConnected = primaryConnected || chestConnected;
+    final bool allSlotsConnected = primaryConnected && chestConnected;
+    final bool showScanSection = !allSlotsConnected;
+
+    // 根據目前配對狀態決定提示文字與顏色，協助使用者理解下一步
+    final String readinessText;
+    final Color readinessColor;
+    if (allSlotsConnected) {
+      readinessText = '兩顆 IMU 已完成配對，可立即開始錄影流程。';
+      readinessColor = const Color(0xFF1E8E5A);
+    } else if (anyConnected) {
+      readinessText = '已連線至少一顆 IMU，仍可透過重新搜尋綁定另一顆裝置。';
+      readinessColor = const Color(0xFF123B70);
+    } else {
+      readinessText = '未連線 IMU 亦可錄影，建議配對以取得揮桿數據。';
+      readinessColor = const Color(0xFF7D8B9A);
+    }
+
+    return Container(
+      margin: const EdgeInsets.symmetric(horizontal: 20, vertical: 16),
+      padding: const EdgeInsets.all(20),
+      decoration: BoxDecoration(
+        color: Colors.white,
+        borderRadius: BorderRadius.circular(24),
+        boxShadow: const [
+          BoxShadow(color: Colors.black12, blurRadius: 14, offset: Offset(0, 6)),
+        ],
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Row(
+            mainAxisAlignment: MainAxisAlignment.spaceBetween,
+            children: [
+              const Text(
+                '連線裝置（自動對設備配對）',
+                style: TextStyle(
+                  fontSize: 18,
+                  fontWeight: FontWeight.bold,
+                  color: Color(0xFF123B70),
+                ),
+              ),
+              Container(
+                width: 28,
+                height: 28,
+                decoration: BoxDecoration(
+                  shape: BoxShape.circle,
+                  border: Border.all(color: const Color(0xFF1E8E5A), width: 2),
+                ),
+              ),
+            ],
+          ),
+          const SizedBox(height: 18),
+          Row(
+            children: [
+              Expanded(
+                child: Column(
+                  children: [
+                    _buildImuSlotRow(
+                      slot: _ImuSlotType.rightWrist,
+                      title: primaryTitle,
+                      statusText: _connectionMessage,
+                      detailText: '電量 $batteryOverview · $firmwareOverview · $primarySignal',
+                      connected: primaryConnected,
+                      onConnectPressed: (_isConnecting || (!primaryConnected && !hasCandidate))
+                          ? null
+                          : () => connectToImu(slot: _ImuSlotType.rightWrist),
+                    ),
+                    const SizedBox(height: 14),
+                    _buildImuSlotRow(
+                      slot: _ImuSlotType.chest,
+                      title: chestTitle,
+                      statusText: _chestConnectionMessage,
+                      detailText: chestDetail,
+                      connected: chestConnected,
+                      onConnectPressed:
+                          _isConnecting ? null : () => connectToImu(slot: _ImuSlotType.chest),
+                    ),
+                  ],
+                ),
+              ),
+            ],
+          ),
+          const SizedBox(height: 16),
+          Row(
+            children: [
+              OutlinedButton.icon(
+                onPressed: _isScanning ? null : scanForImu,
+                icon: Icon(
+                  _isScanning ? Icons.hourglass_empty : Icons.sync,
+                  color: const Color(0xFF123B70),
+                ),
+                label: Text(
+                  _isScanning ? '掃描中' : '重新搜尋',
+                  style: const TextStyle(color: Color(0xFF123B70)),
+                ),
+                style: OutlinedButton.styleFrom(
+                  side: const BorderSide(color: Color(0xFF123B70)),
+                  shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(14)),
+                ),
+              ),
+              const SizedBox(width: 12),
+              Expanded(
+                child: Text(
+                  readinessText,
+                  style: TextStyle(fontSize: 12, color: readinessColor),
+                  textAlign: TextAlign.right,
+                ),
+              ),
+            ],
+          ),
+          if (showScanSection) ...[
+            const SizedBox(height: 20),
+            _buildScanCandidatesSection(),
+          ],
+          if (anyConnected) ...[
+            const SizedBox(height: 20),
+            const Divider(),
+            const SizedBox(height: 16),
+            _buildSensorDataSection(),
+            const SizedBox(height: 20),
+            _buildBatterySection(),
+            const SizedBox(height: 20),
+            _buildDeviceInfoSection(),
+            const SizedBox(height: 20),
+            _buildMotorControlSection(),
+          ],
+        ],
+      ),
+    );
+  }
+
+  Widget _buildImuSlotRow({
+    required _ImuSlotType slot,
+    required String title,
+    required String statusText,
+    required String detailText,
+    required bool connected,
+    required VoidCallback? onConnectPressed,
+  }) {
+    final Color statusColor = connected ? const Color(0xFF1E8E5A) : const Color(0xFF7D8B9A);
+    final IconData icon =
+        slot == _ImuSlotType.rightWrist ? Icons.sports_golf : Icons.accessibility_new;
+    final List<Color> gradientColors = slot == _ImuSlotType.rightWrist
+        ? const [Color(0xFF123B70), Color(0xFF1E8E5A)]
+        : const [Color(0xFF6A1B9A), Color(0xFF26A69A)];
+    final String buttonText = connected
+        ? '重新連線'
+        : (slot == _ImuSlotType.rightWrist ? '配對右手腕' : '配對胸前');
+    final bool motorAvailable = _motorCharacteristicForSlot(slot) != null;
+    final bool motorBusy = _isMotorBusyForSlot(slot);
+
+    return Row(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Container(
+          width: 64,
+          height: 64,
+          decoration: BoxDecoration(
+            borderRadius: BorderRadius.circular(20),
+            gradient: LinearGradient(
+              colors: gradientColors,
+              begin: Alignment.topLeft,
+              end: Alignment.bottomRight,
+            ),
+          ),
+          child: Icon(icon, color: Colors.white, size: 34),
+        ),
+        const SizedBox(width: 20),
+        Expanded(
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Text(
+                title,
+                style: const TextStyle(
+                  fontSize: 18,
+                  fontWeight: FontWeight.bold,
+                  color: Color(0xFF1E1E1E),
+                ),
+              ),
+              const SizedBox(height: 6),
+              Text(
+                statusText,
+                style: TextStyle(fontSize: 13, color: statusColor, fontWeight: FontWeight.w600),
+              ),
+              const SizedBox(height: 4),
+              Text(
+                detailText,
+                style: const TextStyle(fontSize: 12, color: Color(0xFF7D8B9A)),
+              ),
+            ],
+          ),
+        ),
+        const SizedBox(width: 12),
+        Column(
+          crossAxisAlignment: CrossAxisAlignment.end,
+          children: [
+            FilledButton(
+              onPressed: onConnectPressed,
+              style: FilledButton.styleFrom(
+                backgroundColor: connected ? const Color(0xFF1E8E5A) : const Color(0xFF123B70),
+                padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 14),
+                shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(18)),
+              ),
+              child: _isConnecting && onConnectPressed == null
+                  ? const SizedBox(
+                      width: 22,
+                      height: 22,
+                      child: CircularProgressIndicator(strokeWidth: 2.5, color: Colors.white),
+                    )
+                  : Text(
+                      buttonText,
+                      style: const TextStyle(fontSize: 14, fontWeight: FontWeight.bold),
+                    ),
+            ),
+            if (motorAvailable) ...[
+              const SizedBox(height: 8),
+              TextButton.icon(
+                onPressed: motorBusy ? null : () => _triggerMotorPulseForSlot(slot),
+                icon: const Icon(Icons.vibration, size: 18),
+                label: Text(motorBusy ? '震動中…' : '震動識別'),
+                style: TextButton.styleFrom(
+                  foregroundColor: const Color(0xFF123B70),
+                ),
+              ),
+            ],
+          ],
+        ),
+      ],
+    );
+  }
+
+  /// 建構掃描結果列表，列出目前搜尋到的藍牙裝置供使用者挑選
+  Widget _buildScanCandidatesSection() {
+    if (_scanCandidates.isEmpty) {
+      return Container(
+        width: double.infinity,
+        padding: const EdgeInsets.symmetric(vertical: 18, horizontal: 16),
+        decoration: BoxDecoration(
+          color: const Color(0xFFF4F8FB),
+          borderRadius: BorderRadius.circular(18),
+          border: Border.all(color: const Color(0xFFE1E8F0)),
+        ),
+        child: Text(
+          _isScanning
+              ? '正在掃描中，請稍候數秒以取得周邊裝置列表。'
+              : '尚未掃描到符合條件的裝置，請確認 IMU 已開機並靠近手機。',
+          style: const TextStyle(fontSize: 13, color: Color(0xFF7D8B9A)),
+        ),
+      );
+    }
+
+    final List<_ImuScanCandidate> entries = _scanCandidates.values.toList()
+      ..sort((a, b) {
+        if (a.matchesImuService != b.matchesImuService) {
+          return a.matchesImuService ? -1 : 1;
+        }
+        return b.rssi.compareTo(a.rssi);
+      });
+
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        const Text(
+          '掃描到的裝置',
+          style: TextStyle(
+            fontSize: 15,
+            fontWeight: FontWeight.w700,
+            color: Color(0xFF123B70),
+          ),
+        ),
+        const SizedBox(height: 12),
+        for (final candidate in entries) _buildScanCandidateTile(candidate),
+      ],
+    );
+  }
+
+  /// 建構單一掃描結果卡片，提供裝置資訊與選擇按鈕
+  Widget _buildScanCandidateTile(_ImuScanCandidate candidate) {
+    final bool isSelected =
+        _foundDevice?.remoteId == candidate.device.remoteId;
+    final bool matchesService = candidate.matchesImuService;
+    final Color borderColor = isSelected
+        ? const Color(0xFF123B70)
+        : (matchesService ? const Color(0xFF1E8E5A) : const Color(0xFFE1E8F0));
+    final Color iconColor = matchesService
+        ? const Color(0xFF1E8E5A)
+        : const Color(0xFF7D8B9A);
+    final bool isPrimaryAssigned =
+        _connectedDevice?.remoteId == candidate.device.remoteId;
+    final bool isChestAssigned =
+        _secondDevice?.remoteId == candidate.device.remoteId;
+
+    return Container(
+      margin: const EdgeInsets.only(bottom: 12),
+      padding: const EdgeInsets.symmetric(vertical: 14, horizontal: 16),
+      decoration: BoxDecoration(
+        color: isSelected ? const Color(0xFFE8F0FF) : const Color(0xFFF9FBFD),
+        borderRadius: BorderRadius.circular(16),
+        border: Border.all(color: borderColor, width: 1.3),
+      ),
+      child: Row(
+        children: [
+          Icon(
+            matchesService ? Icons.sensors : Icons.bluetooth_searching,
+            color: iconColor,
+            size: 28,
+          ),
+          const SizedBox(width: 12),
+          Expanded(
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Text(
+                  candidate.displayName,
+                  style: const TextStyle(
+                    fontSize: 15,
+                    fontWeight: FontWeight.w600,
+                    color: Color(0xFF123B70),
+                  ),
+                ),
+                const SizedBox(height: 4),
+                Text(
+                  '${matchesService ? '含 IMU 服務' : '未標示 IMU 服務'} · RSSI ${candidate.rssi} dBm',
+                  style: const TextStyle(fontSize: 12, color: Color(0xFF7D8B9A)),
+                ),
+                const SizedBox(height: 2),
+                Text(
+                  '最後出現：${_formatTimeOfDay(candidate.lastSeen)}',
+                  style: const TextStyle(fontSize: 11, color: Color(0xFF9AA8B6)),
+                ),
+              ],
+            ),
+          ),
+          const SizedBox(width: 12),
+          Column(
+            crossAxisAlignment: CrossAxisAlignment.end,
+            children: [
+              FilledButton(
+                onPressed: _isConnecting || isPrimaryAssigned
+                    ? null
+                    : () => connectToImu(
+                          slot: _ImuSlotType.rightWrist,
+                          candidate: candidate.device,
+                          candidateName: candidate.displayName,
+                        ),
+                child: Text(isPrimaryAssigned ? '已綁定右手腕' : '綁定右手腕'),
+              ),
+              const SizedBox(height: 8),
+              FilledButton.tonal(
+                onPressed: _isConnecting || isChestAssigned
+                    ? null
+                    : () => connectToImu(
+                          slot: _ImuSlotType.chest,
+                          candidate: candidate.device,
+                          candidateName: candidate.displayName,
+                        ),
+                child: Text(isChestAssigned ? '已綁定胸前' : '綁定胸前'),
+              ),
+            ],
+          ),
+        ],
+      ),
+    );
+  }
+
+  /// 說明錄影流程的卡片，提醒使用者會切換到新畫面
+  Widget _buildRecordingGuideCard() {
+    return Container(
+      margin: const EdgeInsets.symmetric(horizontal: 20),
+      padding: const EdgeInsets.all(20),
+      decoration: BoxDecoration(
+        color: const Color(0xFFF4F7FB),
+        borderRadius: BorderRadius.circular(20),
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: const [
+          Text(
+            '錄影流程說明',
+            style: TextStyle(
+              fontSize: 16,
+              fontWeight: FontWeight.w700,
+              color: Color(0xFF123B70),
+            ),
+          ),
+          SizedBox(height: 12),
+          Text(
+            '開始錄影後會跳轉至新的錄影畫面，錄影畫面專注於鏡頭預覽、倒數與波形，避免與 IMU 配對資訊混在一起。',
+            style: TextStyle(fontSize: 13, color: Color(0xFF465A71), height: 1.4),
+          ),
+          SizedBox(height: 8),
+          Text(
+            '若尚未連線 IMU，新的錄影畫面仍可啟動純錄影模式，稍後可再返回此頁重新配對。',
+            style: TextStyle(fontSize: 13, color: Color(0xFF465A71), height: 1.4),
+          ),
+          SizedBox(height: 8),
+          Text(
+            '錄影完成後的歷史影片已移至首頁的「錄影歷史」按鈕中，方便集中管理。',
+            style: TextStyle(fontSize: 13, color: Color(0xFF465A71), height: 1.4),
+          ),
+        ],
+      ),
+    );
+  }
+
+  // ---------- 畫面建構 ----------
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('Golf Recorder')),
+      body: ListView(
+        padding: const EdgeInsets.symmetric(vertical: 20),
+        children: [
+          _buildImuConnectionCard(),
+          const SizedBox(height: 8),
+          _buildRecordingGuideCard(),
+        ],
+      ),
+      bottomNavigationBar: SafeArea(
+        child: Padding(
+          padding: const EdgeInsets.fromLTRB(20, 12, 20, 24),
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            crossAxisAlignment: CrossAxisAlignment.stretch,
+            children: [
+              Text(
+                '本次將錄影 $_selectedRounds 次，每次 $_recordingDurationSeconds 秒。',
+                style: const TextStyle(fontSize: 13, color: Color(0xFF465A71)),
+                textAlign: TextAlign.center,
+              ),
+              const SizedBox(height: 10),
+              FilledButton(
+                onPressed:
+                    _isOpeningSession ? null : () => _openRecordingSession(),
+                style: FilledButton.styleFrom(
+                  padding: const EdgeInsets.symmetric(vertical: 18),
+                  shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(18)),
+                  backgroundColor: const Color(0xFF123B70),
+                ),
+                child: Text(
+                  isImuConnected ? '進入錄影畫面' : '進入錄影畫面（純錄影）',
+                  style: const TextStyle(fontSize: 16, fontWeight: FontWeight.w700),
+                ),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
 }
 
+/// 將底層藍牙請求排成序列，避免多個 setNotifyValue 同時進行造成 BUSY 例外
+class _BleOperationQueue {
+  final List<_BleQueuedTask> _queue = <_BleQueuedTask>[]; // 儲存等待執行的任務
+  bool _isRunning = false; // 是否已有任務正在執行
+  bool _isDisposed = false; // 頁面是否已釋放，避免離開後繼續操作藍牙
+
+  /// 將任務加入佇列並依序執行，可設定每筆任務之間的緩衝時間
+  Future<void> enqueue(
+    Future<void> Function() action, {
+    Duration spacing = const Duration(milliseconds: 150),
+  }) {
+    if (_isDisposed) {
+      // 若頁面已銷毀則不再排程，直接回傳已完成的 Future 避免外部 await 卡住
+      return Future.value();
+    }
+
+    final completer = Completer<void>();
+    _queue.add(
+      _BleQueuedTask(
+        run: () async {
+          try {
+            await action();
+            if (!completer.isCompleted) {
+              completer.complete();
+            }
+          } catch (error, stackTrace) {
+            if (!completer.isCompleted) {
+              completer.completeError(error, stackTrace);
+            }
+          }
+        },
+        spacing: spacing,
+      ),
+    );
+    _processQueue();
+    return completer.future;
+  }
+
+  /// 清除所有待執行任務，並阻止後續 enqueue 進入
+  void dispose() {
+    _isDisposed = true;
+    _queue.clear();
+  }
+
+  void _processQueue() {
+    if (_isDisposed || _isRunning || _queue.isEmpty) {
+      return;
+    }
+    _isRunning = true;
+    _runNext();
+  }
+
+  void _runNext() {
+    if (_isDisposed || _queue.isEmpty) {
+      _isRunning = false;
+      return;
+    }
+    final task = _queue.removeAt(0);
+    task.run().whenComplete(() async {
+      if (task.spacing > Duration.zero) {
+        await Future.delayed(task.spacing);
+      }
+      _runNext();
+    });
+  }
+}
+
+/// 描述一筆待處理的 BLE 任務與其間隔設定
+class _BleQueuedTask {
+  final Future<void> Function() run; // 實際執行內容
+  final Duration spacing; // 與下一筆任務的間隔時間
+
+  const _BleQueuedTask({
+    required this.run,
+    required this.spacing,
+  });
+}
+
+/// 代表一次掃描到的藍牙裝置資訊，便於建立列表顯示與更新判斷
+class _ImuScanCandidate {
+  final BluetoothDevice device; // 對應的藍牙裝置物件
+  final String displayName; // 顯示於 UI 的名稱
+  final int rssi; // 訊號強度，單位 dBm
+  final bool matchesImuService; // 是否包含 IMU 相關服務 UUID
+  final DateTime lastSeen; // 最近一次在掃描結果中出現的時間
+
+  const _ImuScanCandidate({
+    required this.device,
+    required this.displayName,
+    required this.rssi,
+    required this.matchesImuService,
+    required this.lastSeen,
+  });
+
+  /// 判斷是否需要以新的掃描結果覆蓋目前資料
+  bool shouldUpdate(_ImuScanCandidate other) {
+    if (other.matchesImuService != matchesImuService) {
+      return true;
+    }
+    if (other.rssi != rssi) {
+      return true;
+    }
+    // 若超過 1 秒未更新則刷新顯示時間，確保列表資訊保持即時
+    return other.lastSeen.difference(lastSeen).inSeconds.abs() >= 1;
+  }
+}

--- a/lib/services/imu_data_logger.dart
+++ b/lib/services/imu_data_logger.dart
@@ -185,6 +185,14 @@ class ImuDataLogger {
     final targetFile = File(targetPath);
 
     await sourceFile.copy(targetFile.path);
+
+    // 確保暫存拍照檔案在複製後即刻刪除，釋放儲存與避免下次讀取到舊檔案。
+    try {
+      await sourceFile.delete();
+    } catch (error) {
+      debugPrint('⚠️ 刪除暫存縮圖檔案失敗：$error');
+    }
+
     return targetFile.path;
   }
 

--- a/lib/services/imu_data_logger.dart
+++ b/lib/services/imu_data_logger.dart
@@ -1,0 +1,321 @@
+import 'dart:async';
+import 'dart:collection';
+import 'dart:io';
+
+import 'package:flutter/foundation.dart';
+import 'package:flutter_blue_plus/flutter_blue_plus.dart';
+import 'package:path/path.dart' as p;
+import 'package:path_provider/path_provider.dart';
+
+/// IMU 原始資料紀錄器：集中管理多裝置的 CSV 寫入流程，確保影片與感測資料對應。
+class ImuDataLogger {
+  ImuDataLogger._();
+
+  /// 單例存取點，方便錄影頁與藍牙頁共用狀態。
+  static final ImuDataLogger instance = ImuDataLogger._();
+
+  final Map<String, _ImuDeviceInfo> _devices = {}; // 目前已連線的裝置資訊
+  final Map<String, _ActiveImuLog> _activeLogs = {}; // 當前錄影輪次的寫入器
+
+  Directory? _storageDirectory; // 應用專屬儲存資料夾
+
+  /// 最多允許同時寫入的裝置數量（依需求限制為 2 台）。
+  static const int _maxDevices = 2;
+
+  /// 登記成功連線的藍牙裝置，後續啟動錄影時會建立對應 CSV。
+  void registerDevice(
+    BluetoothDevice device, {
+    required String displayName,
+    required String slotAlias,
+  }) {
+    final deviceId = device.remoteId.str;
+    _devices[deviceId] = _ImuDeviceInfo(
+      deviceId: deviceId,
+      displayName: displayName,
+      slotAlias: slotAlias,
+      connectedAt: DateTime.now(),
+    );
+  }
+
+  /// 連線斷開時移除裝置資訊，避免後續繼續寫入失效檔案。
+  void unregisterDevice(String deviceId) {
+    _devices.remove(deviceId);
+    _activeLogs.remove(deviceId)?.dispose(deleteFile: true);
+  }
+
+  /// 依照錄影輪次產生具可讀性的檔名基底（round_序號_時間戳）。
+  String buildBaseFileName({required int roundIndex, DateTime? timestamp}) {
+    final time = timestamp ?? DateTime.now();
+    final buffer = StringBuffer('round_')
+      ..write(roundIndex)
+      ..write('_')
+      ..write(time.year.toString().padLeft(4, '0'))
+      ..write(time.month.toString().padLeft(2, '0'))
+      ..write(time.day.toString().padLeft(2, '0'))
+      ..write('_')
+      ..write(time.hour.toString().padLeft(2, '0'))
+      ..write(time.minute.toString().padLeft(2, '0'))
+      ..write(time.second.toString().padLeft(2, '0'));
+    return buffer.toString();
+  }
+
+  /// 啟動新的錄影輪次，為每台裝置建立 CSV 檔頭。
+  Future<void> startRoundLogging(String baseName) async {
+    await abortActiveRound(); // 確保先前輪次完整清除
+    if (_devices.isEmpty) {
+      return; // 沒有裝置連線時不建立任何檔案
+    }
+
+    final directory = await _ensureStorageDirectory();
+
+    final devices = _devices.values.toList()
+      ..sort((a, b) => a.connectedAt.compareTo(b.connectedAt));
+
+    for (int i = 0; i < devices.length && i < _maxDevices; i++) {
+      final info = devices[i];
+      final alias = info.slotAlias;
+      final filePath = p.join(directory.path, '${baseName}_$alias.csv');
+      final file = File(filePath);
+      final existed = await file.exists();
+      final sink = file.openWrite(mode: FileMode.writeOnlyAppend);
+
+      // ---------- CSV 檔頭區 ----------
+      // 若為首次建立檔案，補上格式宣告行，模擬參考專案中的 saveToCSVFile_V3 行為。
+      if (!existed) {
+        sink.writeln('CODI_RAW_V1');
+      } else {
+        // 續寫時額外加上空行分隔不同錄影輪次的資料。
+        sink.writeln();
+      }
+      // 先寫入裝置名稱方便離線處理鎖定目標裝置，接著依指定順序輸出四元數與線性加速度欄位。
+      sink.writeln('Device:${info.displayName}');
+      sink.writeln('QuatI,QuatJ,QuatK,QuatW,AccelX,AccelY,AccelZ');
+
+      _activeLogs[info.deviceId] = _ActiveImuLog(
+        alias: alias,
+        filePath: filePath,
+        sink: sink,
+      );
+    }
+  }
+
+  /// 暫存線性加速度封包，待旋轉資料到齊後依序寫入。
+  void logLinearAcceleration(
+    String deviceId,
+    Map<String, dynamic> sample,
+    List<int> _rawBytes,
+  ) {
+    final log = _activeLogs[deviceId];
+    if (log == null) return;
+    // ---------- 線性加速度入隊 ----------
+    log.linearQueue.add(Map<String, dynamic>.from(sample));
+    _drainSynchronizedSamples(log);
+  }
+
+  /// 暫存 Game Rotation Vector 封包資料，待線性資料到齊後依序寫入。
+  void logGameRotationVector(
+    String deviceId,
+    Map<String, dynamic> sample,
+    List<int> _rawBytes,
+  ) {
+    final log = _activeLogs[deviceId];
+    if (log == null) return;
+    // ---------- Game Rotation Vector 入隊 ----------
+    log.rotationQueue.add(Map<String, dynamic>.from(sample));
+    _drainSynchronizedSamples(log);
+  }
+
+  /// 結束目前錄影輪次，關閉檔案並回傳裝置對應的 CSV 路徑。
+  Future<Map<String, String>> finishRoundLogging() async {
+    final results = <String, String>{};
+    for (final entry in _activeLogs.entries) {
+      _flushPendingSamples(entry.value, force: true);
+      await entry.value.sink.flush();
+      await entry.value.sink.close();
+      final alias = _devices[entry.key]?.slotAlias ?? entry.key;
+      results[alias] = entry.value.filePath;
+    }
+    _activeLogs.clear();
+    return results;
+  }
+
+  /// 若錄影中途取消，刪除尚未完成的 CSV 以免留下空檔。
+  Future<void> abortActiveRound() async {
+    for (final entry in _activeLogs.entries) {
+      entry.value.clearQueues();
+      await entry.value.sink.close();
+      final file = File(entry.value.filePath);
+      if (await file.exists()) {
+        await file.delete();
+      }
+    }
+    _activeLogs.clear();
+  }
+
+  /// 將臨時影片複製到專屬資料夾，並與 CSV 使用相同檔名基底。
+  Future<String> persistVideoFile({
+    required String sourcePath,
+    required String baseName,
+  }) async {
+    final directory = await _ensureStorageDirectory();
+    final targetPath = p.join(directory.path, '$baseName.mp4');
+    final sourceFile = File(sourcePath);
+    final targetFile = File(targetPath);
+    await sourceFile.copy(targetFile.path);
+    return targetFile.path;
+  }
+
+  /// 將以 `CameraController.takePicture` 取得的靜態圖複製到專屬資料夾。
+  ///
+  /// 以前改用從影片擷取影格的方式時，Android 會持續出現
+  /// `Unable to acquire a buffer item` 警告。改用拍照取得縮圖後，
+  /// 就能避免 MediaMetadataRetriever 與錄影流程互搶緩衝區。
+  Future<String?> persistThumbnailFromPicture({
+    required String sourcePath,
+    required String baseName,
+  }) async {
+    final sourceFile = File(sourcePath);
+    if (!await sourceFile.exists()) {
+      debugPrint('⚠️ 找不到暫存縮圖檔案：$sourcePath');
+      return null;
+    }
+
+    final directory = await _ensureStorageDirectory();
+    final targetPath = p.join(directory.path, '${baseName}_thumb.jpg');
+    final targetFile = File(targetPath);
+
+    await sourceFile.copy(targetFile.path);
+    return targetFile.path;
+  }
+
+  /// 判斷目前是否仍有尚未完成的 CSV 寫入流程。
+  bool get hasActiveRound => _activeLogs.isNotEmpty;
+
+  /// 取得當前儲存資料夾，若不存在則建立。
+  Future<Directory> _ensureStorageDirectory() async {
+    if (_storageDirectory != null) {
+      return _storageDirectory!;
+    }
+    final baseDir = await getApplicationDocumentsDirectory();
+    final target = Directory(p.join(baseDir.path, 'imu_records'));
+    if (!await target.exists()) {
+      await target.create(recursive: true);
+    }
+    _storageDirectory = target;
+    return target;
+  }
+
+  /// 從隊列中同步線性與旋轉資料，忽略時間戳以先進先出方式合併。
+  void _drainSynchronizedSamples(_ActiveImuLog log) {
+    while (log.linearQueue.isNotEmpty && log.rotationQueue.isNotEmpty) {
+      final linear = log.linearQueue.removeFirst();
+      final rotation = log.rotationQueue.removeFirst();
+      _writeCombinedSample(log, linear, rotation);
+    }
+  }
+
+  /// 在輪次結束或逾時時輸出剩餘資料，force=true 代表即使缺資料也要寫出。
+  void _flushPendingSamples(_ActiveImuLog log, {required bool force}) {
+    if (!force) {
+      _drainSynchronizedSamples(log);
+      return;
+    }
+
+    // force=true 時仍只保留最小長度的有效資料，多出的項目直接丟棄避免欄位錯位。
+    while (log.linearQueue.isNotEmpty && log.rotationQueue.isNotEmpty) {
+      final linear = log.linearQueue.removeFirst();
+      final rotation = log.rotationQueue.removeFirst();
+      _writeCombinedSample(log, linear, rotation);
+    }
+
+    // 任何尚未配對的殘餘資料都直接清除，確保輸出長度一致。
+    log.linearQueue.clear();
+    log.rotationQueue.clear();
+  }
+
+  /// 寫出單列資料，缺少的欄位以空字串補齊保持欄位順序。
+  void _writeCombinedSample(
+    _ActiveImuLog log,
+    Map<String, dynamic>? linear,
+    Map<String, dynamic>? rotation,
+  ) {
+    if (linear == null && rotation == null) {
+      return;
+    }
+    final values = <String>[
+      _formatNumeric(rotation?['i']),
+      _formatNumeric(rotation?['j']),
+      _formatNumeric(rotation?['k']),
+      _formatNumeric(rotation?['real'] ?? rotation?['w']),
+      _formatNumeric(linear?['x']),
+      _formatNumeric(linear?['y']),
+      _formatNumeric(linear?['z']),
+    ];
+    log.sink.writeln(values.join(','));
+  }
+
+  /// 將非空數值轉為字串，避免 null 導致欄位錯位。
+  String _formatNumeric(Object? value) {
+    if (value == null) {
+      return '';
+    }
+    if (value is num) {
+      return value.toStringAsFixed(6);
+    }
+    final parsed = double.tryParse(value.toString());
+    return parsed?.toStringAsFixed(6) ?? value.toString();
+  }
+}
+
+/// 封裝裝置資訊，保留連線時間供排序使用。
+class _ImuDeviceInfo {
+  final String deviceId;
+  final String displayName;
+  final String slotAlias;
+  final DateTime connectedAt;
+
+  _ImuDeviceInfo({
+    required this.deviceId,
+    required this.displayName,
+    required this.slotAlias,
+    required this.connectedAt,
+  });
+
+  /// 產生適合用於檔名的縮短標籤，移除特殊字元。
+  String get shortName {
+    final sanitized = displayName.replaceAll(RegExp(r'[^A-Za-z0-9]+'), '_');
+    return sanitized.isEmpty ? 'imu' : sanitized.toLowerCase();
+  }
+}
+
+/// 單一裝置在錄影輪次中的寫入資訊。
+class _ActiveImuLog {
+  final String alias; // 方便辨識裝置的簡短代號
+  final String filePath; // 對應的 CSV 完整路徑
+  final IOSink sink; // 寫入串流
+  final ListQueue<Map<String, dynamic>> linearQueue = ListQueue(); // 線性加速度 FIFO
+  final ListQueue<Map<String, dynamic>> rotationQueue = ListQueue(); // 旋轉向量 FIFO
+
+  _ActiveImuLog({
+    required this.alias,
+    required this.filePath,
+    required this.sink,
+  });
+
+  /// 關閉寫入器並視需求刪除檔案。
+  Future<void> dispose({bool deleteFile = false}) async {
+    await sink.close();
+    if (deleteFile) {
+      final file = File(filePath);
+      if (await file.exists()) {
+        await file.delete();
+      }
+    }
+  }
+
+  /// 清空所有佇列，通常用於取消錄影時同步重置狀態。
+  void clearQueues() {
+    linearQueue.clear();
+    rotationQueue.clear();
+  }
+}

--- a/lib/services/recording_history_storage.dart
+++ b/lib/services/recording_history_storage.dart
@@ -1,0 +1,83 @@
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:path/path.dart' as p;
+import 'package:path_provider/path_provider.dart';
+
+import '../models/recording_history_entry.dart';
+
+/// 錄影歷史儲存工具：負責將紀錄寫入 JSON 並在啟動時還原
+class RecordingHistoryStorage {
+  RecordingHistoryStorage._();
+
+  /// 提供單例呼叫，避免重複建立檔案 IO 資源
+  static final RecordingHistoryStorage instance = RecordingHistoryStorage._();
+
+  static const String _folderName = 'imu_records'; // 與影片、CSV 相同的資料夾
+  static const String _fileName = 'recording_history.json'; // 歷史紀錄檔案名稱
+
+  /// 讀取歷史紀錄，失敗時回傳空陣列避免打斷 UI
+  Future<List<RecordingHistoryEntry>> loadHistory() async {
+    try {
+      final file = await _resolveHistoryFile();
+      if (!await file.exists()) {
+        return [];
+      }
+
+      final content = await file.readAsString();
+      if (content.trim().isEmpty) {
+        return [];
+      }
+
+      final decoded = jsonDecode(content);
+      if (decoded is! List) {
+        return [];
+      }
+
+      final entries = <RecordingHistoryEntry>[];
+      for (final item in decoded) {
+        if (item is Map<String, dynamic>) {
+          entries.add(RecordingHistoryEntry.fromJson(item));
+        } else if (item is Map) {
+          // 將動態 Map 轉為字串鍵值，避免型別轉換問題
+          entries.add(
+            RecordingHistoryEntry.fromJson(
+              item.map((key, value) => MapEntry(key.toString(), value)),
+            ),
+          );
+        }
+      }
+
+      // 依照時間新到舊排序，確保 UI 顯示一致
+      entries.sort((a, b) => b.recordedAt.compareTo(a.recordedAt));
+
+      // 過濾掉已經不存在的影片，避免點擊後找不到檔案
+      return entries
+          .where((entry) => File(entry.filePath).existsSync())
+          .toList(growable: false);
+    } catch (_) {
+      return [];
+    }
+  }
+
+  /// 將最新歷史寫入檔案，若資料夾不存在會自動建立
+  Future<void> saveHistory(List<RecordingHistoryEntry> entries) async {
+    try {
+      final file = await _resolveHistoryFile();
+      final payload = entries.map((e) => e.toJson()).toList(growable: false);
+      await file.writeAsString(jsonEncode(payload));
+    } catch (_) {
+      // 寫入失敗時保持靜默，避免影響錄影流程
+    }
+  }
+
+  /// 取得紀錄檔案路徑，並確保資料夾已建立
+  Future<File> _resolveHistoryFile() async {
+    final baseDir = await getApplicationDocumentsDirectory();
+    final targetDir = Directory(p.join(baseDir.path, _folderName));
+    if (!await targetDir.exists()) {
+      await targetDir.create(recursive: true);
+    }
+    return File(p.join(targetDir.path, _fileName));
+  }
+}

--- a/lib/widgets/recording_history_sheet.dart
+++ b/lib/widgets/recording_history_sheet.dart
@@ -1,0 +1,177 @@
+import 'package:flutter/material.dart';
+
+import '../models/recording_history_entry.dart';
+
+/// 自訂底部彈窗，統一顯示錄影歷史列表與播放行為
+Future<void> showRecordingHistorySheet({
+  required BuildContext context,
+  required List<RecordingHistoryEntry> entries,
+  required ValueChanged<RecordingHistoryEntry> onPlayEntry,
+  VoidCallback? onPickExternal,
+  String title = '曾經錄影紀錄',
+}) {
+  return showModalBottomSheet(
+    context: context,
+    isScrollControlled: true,
+    shape: const RoundedRectangleBorder(
+      borderRadius: BorderRadius.vertical(top: Radius.circular(24)),
+    ),
+    builder: (sheetContext) {
+      final displayEntries = List<RecordingHistoryEntry>.from(entries);
+
+      return FractionallySizedBox(
+        heightFactor: 0.7,
+        child: SafeArea(
+          child: Padding(
+            padding: const EdgeInsets.fromLTRB(20, 16, 20, 24),
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Center(
+                  child: Container(
+                    width: 40,
+                    height: 4,
+                    decoration: BoxDecoration(
+                      color: Colors.grey.shade400,
+                      borderRadius: BorderRadius.circular(2),
+                    ),
+                  ),
+                ),
+                const SizedBox(height: 12),
+                Text(
+                  title,
+                  style: const TextStyle(
+                    fontSize: 18,
+                    fontWeight: FontWeight.w700,
+                    color: Color(0xFF123B70),
+                  ),
+                ),
+                const SizedBox(height: 16),
+                if (displayEntries.isEmpty)
+                  Expanded(
+                    child: Column(
+                      mainAxisAlignment: MainAxisAlignment.center,
+                      children: const [
+                        Icon(Icons.video_collection_outlined, size: 56, color: Color(0xFF9AA6B2)),
+                        SizedBox(height: 12),
+                        Text(
+                          '目前沒有錄影紀錄，完成錄影後會自動顯示在此處。',
+                          style: TextStyle(fontSize: 13, color: Color(0xFF6F7B86)),
+                          textAlign: TextAlign.center,
+                        ),
+                      ],
+                    ),
+                  )
+                else
+                  Expanded(
+                    child: ListView.separated(
+                      itemCount: displayEntries.length,
+                      separatorBuilder: (_, __) => const SizedBox(height: 12),
+                      itemBuilder: (context, index) {
+                        final entry = displayEntries[index];
+                        return InkWell(
+                          borderRadius: BorderRadius.circular(16),
+                          onTap: () {
+                            Navigator.pop(sheetContext);
+                            onPlayEntry(entry);
+                          },
+                          child: Container(
+                            padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 14),
+                            decoration: BoxDecoration(
+                              color: const Color(0xFFF4F7FB),
+                              borderRadius: BorderRadius.circular(16),
+                            ),
+                            child: Row(
+                              children: [
+                                CircleAvatar(
+                                  radius: 20,
+                                  backgroundColor: const Color(0xFF123B70),
+                                  child: Text(
+                                    entry.roundIndex.toString(),
+                                    style: const TextStyle(
+                                      color: Colors.white,
+                                      fontWeight: FontWeight.bold,
+                                    ),
+                                  ),
+                                ),
+                                const SizedBox(width: 14),
+                                Expanded(
+                                  child: Column(
+                                    crossAxisAlignment: CrossAxisAlignment.start,
+                                    children: [
+                                      Text(
+                                        entry.displayTitle,
+                                        style: const TextStyle(
+                                          fontSize: 15,
+                                          fontWeight: FontWeight.w600,
+                                          color: Color(0xFF123B70),
+                                        ),
+                                      ),
+                                      const SizedBox(height: 4),
+                                      Text(
+                                        _buildSubtitle(entry),
+                                        style: const TextStyle(fontSize: 12, color: Color(0xFF6F7B86)),
+                                      ),
+                                    ],
+                                  ),
+                                ),
+                                const Icon(Icons.play_arrow_rounded, color: Color(0xFF1E8E5A), size: 28),
+                              ],
+                            ),
+                          ),
+                        );
+                      },
+                    ),
+                  ),
+                if (onPickExternal != null) ...[
+                  const SizedBox(height: 16),
+                  FilledButton.icon(
+                    onPressed: () {
+                      Navigator.pop(sheetContext);
+                      onPickExternal();
+                    },
+                    style: FilledButton.styleFrom(
+                      minimumSize: const Size.fromHeight(48),
+                      backgroundColor: const Color(0xFF123B70),
+                      shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(16)),
+                    ),
+                    icon: const Icon(Icons.folder_open),
+                    label: const Text('從檔案資料夾選取影片'),
+                  ),
+                ],
+              ],
+            ),
+          ),
+        ),
+      );
+    },
+  );
+}
+
+/// 將錄影紀錄的時間與模式組合成描述文字
+String _buildSubtitle(RecordingHistoryEntry entry) {
+  final buffer = StringBuffer()
+    ..write(_formatTimestamp(entry.recordedAt))
+    ..write(' · ')
+    ..write('${entry.durationSeconds}\u0020秒')
+    ..write(' · ')
+    ..write(entry.modeLabel)
+    ..write('\n')
+    ..write(entry.fileName);
+  if (entry.hasImuCsv) {
+    buffer
+      ..write('\n')
+      ..write('IMU CSV：')
+      ..write(entry.csvFileNames.join(', '));
+  }
+  return buffer.toString();
+}
+
+/// 以簡潔格式顯示日期時間，避免依賴額外套件
+String _formatTimestamp(DateTime time) {
+  final month = time.month.toString().padLeft(2, '0');
+  final day = time.day.toString().padLeft(2, '0');
+  final hour = time.hour.toString().padLeft(2, '0');
+  final minute = time.minute.toString().padLeft(2, '0');
+  return '${time.year}/$month/$day $hour:$minute';
+}

--- a/local_plugins/assets_audio_player/android/build.gradle
+++ b/local_plugins/assets_audio_player/android/build.gradle
@@ -2,14 +2,17 @@ group 'com.github.florent37.assets_audio_player'
 version '1.0-SNAPSHOT'
 
 buildscript {
-    ext.kotlin_version = '1.8.22'
+    // ---------- Kotlin 與 AGP 版本設定 ----------
+    // 為與主專案同步回退至 Kotlin 2.0.21，確保相依套件不會因 metadata 版本差異而失敗
+    // 仍維持 AGP 8.7.0 以符合 Flutter 建置需求
+    ext.kotlin_version = '2.0.21'
     repositories {
         google()
         mavenCentral()
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:7.3.1'
+        classpath 'com.android.tools.build:gradle:8.7.0'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
     }
 }
@@ -24,9 +27,22 @@ rootProject.allprojects {
 apply plugin: 'com.android.library'
 apply plugin: 'kotlin-android'
 
+// ---------- 依賴解析區 ----------
+// 與主專案一致鎖定 Kotlin 標準函式庫版本，避免編譯時發生 metadata 與編譯器版本不符
+configurations.all { config ->
+    config.resolutionStrategy.eachDependency { details ->
+        if (details.requested.group == 'org.jetbrains.kotlin' && details.requested.name.startsWith('kotlin-')) {
+            details.useVersion(kotlin_version)
+            details.because('鎖定 Kotlin 標準函式庫版本，避免 Binary version 差異造成編譯錯誤')
+        }
+    }
+}
+
 android {
     namespace 'com.github.florent37.assets_audio_player'
-    compileSdkVersion 31
+    // ---------- 編譯設定 ----------
+    // 提升 compileSdk 至 36，與主應用程式保持一致以避免 API 相容性問題
+    compileSdkVersion 36
 
     if (project.android.hasProperty("namespace")) {
         namespace 'com.github.florent37.assets_audio_player'
@@ -39,11 +55,15 @@ android {
         multiDexEnabled true
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }
-    lintOptions {
+    lint {
+        // 停用舊版打包警告，避免阻斷編譯流程
         disable 'InvalidPackage'
     }
     packagingOptions {
-        exclude "DebugProbesKt.bin"
+        resources {
+            // 排除 Kotlin 偵錯探針檔案，減少不必要的資源衝突
+            excludes += "DebugProbesKt.bin"
+        }
     }
     compileOptions {
         // 統一 Java 編譯目標版本為 11

--- a/local_plugins/assets_audio_player/android/src/main/kotlin/com/github/florent37/assets_audio_player/stopwhencall/HeadsetManager.kt
+++ b/local_plugins/assets_audio_player/android/src/main/kotlin/com/github/florent37/assets_audio_player/stopwhencall/HeadsetManager.kt
@@ -88,14 +88,16 @@ class HeadsetManager(private val context: Context) {
 
 
     fun Context.hasPermissionBluetooth() : Boolean {
-        try {
+        return try {
             val packageInfo = this.packageManager.getPackageInfo(packageName, PackageManager.GET_PERMISSIONS)
-            return  packageInfo.requestedPermissions.contains("android.permission.BLUETOOTH")
+            // ---------- 權限檢查 ----------
+            // requestedPermissions 可能為 null，使用安全呼叫避免拋出 NullPointerException
+            packageInfo.requestedPermissions?.contains("android.permission.BLUETOOTH") == true
         } catch (t: Throwable) {
-
+            // ---------- 例外處理 ----------
+            // 無法取得套件資訊時視同未宣告藍牙權限
+            false
         }
-
-        return false
     }
 
 }

--- a/local_plugins/assets_audio_player/assets_audio_player_web/android/build.gradle
+++ b/local_plugins/assets_audio_player/assets_audio_player_web/android/build.gradle
@@ -2,14 +2,16 @@ group 'com.github.florent37.assets_audio_player_web'
 version '1.0-SNAPSHOT'
 
 buildscript {
-    ext.kotlin_version = '1.8.22'
+    // ---------- Kotlin 與 AGP 版本設定 ----------
+    // 使用與主專案相同的 Kotlin 2.0.21 / AGP 8.7.0 組合，避免編譯器版本不一致
+    ext.kotlin_version = '2.0.21'
     repositories {
         google()
         mavenCentral()
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:7.3.1'
+        classpath 'com.android.tools.build:gradle:8.7.0'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
     }
 }
@@ -24,7 +26,9 @@ rootProject.allprojects {
 apply plugin: 'com.android.library'
 apply plugin: 'kotlin-android'
 android {
-    compileSdkVersion 34
+    // ---------- 編譯設定 ----------
+    // 提升 compileSdk 至 36 與應用同步，確保匯入 Element 素材時不會產生 API 差異
+    compileSdkVersion 36
 
     //if (project.android.hasProperty("namespace")) {
         namespace 'com.github.florent37.assets_audio_player_web'
@@ -36,7 +40,8 @@ android {
     defaultConfig {
         minSdkVersion 16
     }
-    lintOptions {
+    lint {
+        // 停用舊版套件常見的 package 名稱警告
         disable 'InvalidPackage'
     }
     compileOptions {

--- a/local_plugins/assets_audio_player/example/android/app/build.gradle
+++ b/local_plugins/assets_audio_player/example/android/app/build.gradle
@@ -21,18 +21,23 @@ if (flutterVersionName == null) {
     flutterVersionName = '1.0'
 }
 
+// ---------- 外掛設定 ----------
+// 使用新版 AGP 與 Kotlin 外掛，確保範例專案與主專案編譯環境一致
 apply plugin: 'com.android.application'
 apply plugin: 'kotlin-android'
 apply from: "$flutterRoot/packages/flutter_tools/gradle/flutter.gradle"
 
 android {
-    compileSdkVersion 32
+    // ---------- 編譯設定 ----------
+    // 與主專案同步使用 API 36，避免測試時遇到版本相容問題
+    compileSdkVersion 36
 
     sourceSets {
         main.java.srcDirs += 'src/main/kotlin'
     }
 
-    lintOptions {
+    lint {
+        // 停用舊版套件帶來的無效套件名稱警告
         disable 'InvalidPackage'
     }
 
@@ -40,7 +45,7 @@ android {
         // TODO: Specify your own unique Application ID (https://developer.android.com/studio/build/application-id.html).
         applicationId "com.github.florent37.example"
         minSdkVersion 19
-        targetSdkVersion 32
+        targetSdkVersion 36
         versionCode flutterVersionCode.toInteger()
         versionName flutterVersionName
     }

--- a/local_plugins/assets_audio_player/example/android/build.gradle
+++ b/local_plugins/assets_audio_player/example/android/build.gradle
@@ -1,12 +1,14 @@
 buildscript {
-    ext.kotlin_version = '1.8.22'
+    // ---------- Kotlin 與 AGP 版本同步 ----------
+    // 範例專案沿用主專案的 Kotlin 2.0.21 / AGP 8.7.0，避免在開發時遇到編譯器不相容
+    ext.kotlin_version = '2.0.21'
     repositories {
         google()
         mavenCentral()
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:7.0.2'
+        classpath 'com.android.tools.build:gradle:8.7.0'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
     }
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -38,7 +38,9 @@ dependencies:
   flutter_blue_plus: ^1.32.5
   path_provider: ^2.1.1
   share_plus: ^7.2.1
-  wakelock_plus: ^1.2.7
+  # ---------- 醒屏控制 ----------
+  # 鎖定為 1.2.7 版以避免 1.4.0 以上對 Kotlin 2.2 的依賴導致本專案降版後無法編譯
+  wakelock_plus: 1.2.7
  
   assets_audio_player:
     path: local_plugins/assets_audio_player  # 使用本地修改版以支援 Dart 3

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -35,6 +35,10 @@ dependencies:
   permission_handler: ^12.0.1
   file_picker: ^10.2.0
   video_player: ^2.7.0
+  flutter_blue_plus: ^1.32.5
+  path_provider: ^2.1.1
+  share_plus: ^7.2.1
+  wakelock_plus: ^1.2.7
  
   assets_audio_player:
     path: local_plugins/assets_audio_player  # 使用本地修改版以支援 Dart 3
@@ -65,6 +69,9 @@ dependency_overrides:
     path: flutter_ignore_plugin/file_picker_linux
   file_picker_windows:
     path: flutter_ignore_plugin/file_picker_windows
+  # ---------- 指定舊版 package_info_plus ----------
+  # share_plus 目前引入 9.x 版且需要 Kotlin 2.2，為避免與專案降版衝突，強制改用 8.0.2 仍可提供版本資訊功能
+  package_info_plus: 8.0.2
 
 
 # The following section is specific to Flutter packages.

--- a/test/widget_test.dart
+++ b/test/widget_test.dart
@@ -1,34 +1,29 @@
-// This is a basic Flutter widget test.
-//
-// To perform an interaction with a widget in your test, use the WidgetTester
-// utility in the flutter_test package. For example, you can send tap and scroll
-// gestures. You can also use WidgetTester to find child widgets in the widget
-// tree, read text, and verify that the values of widget properties are correct.
+// 基本的 Flutter Widget 測試，確認應用入口可以正常建立 UI。
 
+import 'package:camera/camera.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 import 'package:golf_score_app/main.dart';
-
-import 'package:camera/camera.dart';
+import 'package:golf_score_app/pages/login_page.dart';
 
 void main() {
-  testWidgets('Counter increments smoke test', (WidgetTester tester) async {
-    // Build our app and trigger a frame.
+  testWidgets('應用啟動後顯示登入頁', (WidgetTester tester) async {
+    // ---------- 測試前置 ----------
+    // 建立空的鏡頭清單，模擬測試環境沒有實體相機。
+    const List<CameraDescription> fakeCameras = <CameraDescription>[];
 
-    final List<CameraDescription> fakeCameras = [];
-    await tester.pumpWidget( MyApp(cameras: fakeCameras));
-    expect(find.byType(MyApp), findsOneWidget);
-    // Verify that our counter starts at 0.
-    expect(find.text('0'), findsOneWidget);
-    expect(find.text('1'), findsNothing);
+    // ---------- 測試步驟 ----------
+    await tester.pumpWidget(
+      const MyApp(
+        initialCameras: fakeCameras,
+        initialCameraError: null,
+      ),
+    );
+    await tester.pumpAndSettle();
 
-    // Tap the '+' icon and trigger a frame.
-    await tester.tap(find.byIcon(Icons.add));
-    await tester.pump();
-
-    // Verify that our counter has incremented.
-    expect(find.text('0'), findsNothing);
-    expect(find.text('1'), findsOneWidget);
+    // ---------- 驗證結果 ----------
+    expect(find.byType(MaterialApp), findsOneWidget);
+    expect(find.byType(LoginPage), findsOneWidget);
   });
 }


### PR DESCRIPTION
## 摘要
- 錄影完成後改用 takePicture 拍攝縮圖並立即寫入紀錄，避免出現 ImageReader 緩衝區警告。
- IMU 資料紀錄器新增縮圖複製工具並移除 video_thumbnail 依賴來源。
- 首頁載入歷史時僅清空無效縮圖欄位，防止舊資料再次觸發擷取流程。

## 測試
- 未執行（環境限制）

------
https://chatgpt.com/codex/tasks/task_e_68de2c90724c8324941f4ed0d6597fc4